### PR TITLE
chore: update with latest upstream starter (a3ff620)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1944,7 +1944,7 @@ dependencies = [
 [[package]]
 name = "ibc"
 version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=4463366e65#4463366e651c0d88dd2fc2923a1b6fff489cae3e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=bcd808832e#bcd808832ed11af340f9a8b24f89bef07c4f125a"
 dependencies = [
  "ibc-apps",
  "ibc-clients",
@@ -1957,7 +1957,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer"
 version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=4463366e65#4463366e651c0d88dd2fc2923a1b6fff489cae3e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=bcd808832e#bcd808832ed11af340f9a8b24f89bef07c4f125a"
 dependencies = [
  "ibc-app-transfer-types",
  "ibc-core",
@@ -1967,7 +1967,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer-types"
 version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=4463366e65#4463366e651c0d88dd2fc2923a1b6fff489cae3e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=bcd808832e#bcd808832ed11af340f9a8b24f89bef07c4f125a"
 dependencies = [
  "borsh",
  "derive_more",
@@ -1983,7 +1983,7 @@ dependencies = [
 [[package]]
 name = "ibc-apps"
 version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=4463366e65#4463366e651c0d88dd2fc2923a1b6fff489cae3e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=bcd808832e#bcd808832ed11af340f9a8b24f89bef07c4f125a"
 dependencies = [
  "ibc-app-transfer",
 ]
@@ -1991,7 +1991,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint"
 version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=4463366e65#4463366e651c0d88dd2fc2923a1b6fff489cae3e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=bcd808832e#bcd808832ed11af340f9a8b24f89bef07c4f125a"
 dependencies = [
  "derive_more",
  "ibc-client-tendermint-types",
@@ -2008,7 +2008,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint-types"
 version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=4463366e65#4463366e651c0d88dd2fc2923a1b6fff489cae3e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=bcd808832e#bcd808832ed11af340f9a8b24f89bef07c4f125a"
 dependencies = [
  "displaydoc",
  "ibc-core-client-types",
@@ -2025,7 +2025,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-wasm-types"
 version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=4463366e65#4463366e651c0d88dd2fc2923a1b6fff489cae3e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=bcd808832e#bcd808832ed11af340f9a8b24f89bef07c4f125a"
 dependencies = [
  "base64 0.21.7",
  "displaydoc",
@@ -2038,7 +2038,7 @@ dependencies = [
 [[package]]
 name = "ibc-clients"
 version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=4463366e65#4463366e651c0d88dd2fc2923a1b6fff489cae3e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=bcd808832e#bcd808832ed11af340f9a8b24f89bef07c4f125a"
 dependencies = [
  "ibc-client-tendermint",
  "ibc-client-wasm-types",
@@ -2047,7 +2047,7 @@ dependencies = [
 [[package]]
 name = "ibc-core"
 version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=4463366e65#4463366e651c0d88dd2fc2923a1b6fff489cae3e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=bcd808832e#bcd808832ed11af340f9a8b24f89bef07c4f125a"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -2063,7 +2063,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel"
 version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=4463366e65#4463366e651c0d88dd2fc2923a1b6fff489cae3e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=bcd808832e#bcd808832ed11af340f9a8b24f89bef07c4f125a"
 dependencies = [
  "ibc-core-channel-types",
  "ibc-core-client",
@@ -2078,7 +2078,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel-types"
 version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=4463366e65#4463366e651c0d88dd2fc2923a1b6fff489cae3e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=bcd808832e#bcd808832ed11af340f9a8b24f89bef07c4f125a"
 dependencies = [
  "borsh",
  "derive_more",
@@ -2099,7 +2099,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client"
 version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=4463366e65#4463366e651c0d88dd2fc2923a1b6fff489cae3e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=bcd808832e#bcd808832ed11af340f9a8b24f89bef07c4f125a"
 dependencies = [
  "ibc-core-client-context",
  "ibc-core-client-types",
@@ -2112,7 +2112,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-context"
 version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=4463366e65#4463366e651c0d88dd2fc2923a1b6fff489cae3e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=bcd808832e#bcd808832ed11af340f9a8b24f89bef07c4f125a"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -2128,7 +2128,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-types"
 version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=4463366e65#4463366e651c0d88dd2fc2923a1b6fff489cae3e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=bcd808832e#bcd808832ed11af340f9a8b24f89bef07c4f125a"
 dependencies = [
  "borsh",
  "derive_more",
@@ -2146,7 +2146,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-commitment-types"
 version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=4463366e65#4463366e651c0d88dd2fc2923a1b6fff489cae3e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=bcd808832e#bcd808832ed11af340f9a8b24f89bef07c4f125a"
 dependencies = [
  "borsh",
  "derive_more",
@@ -2162,7 +2162,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-connection"
 version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=4463366e65#4463366e651c0d88dd2fc2923a1b6fff489cae3e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=bcd808832e#bcd808832ed11af340f9a8b24f89bef07c4f125a"
 dependencies = [
  "ibc-core-client",
  "ibc-core-connection-types",
@@ -2174,7 +2174,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-connection-types"
 version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=4463366e65#4463366e651c0d88dd2fc2923a1b6fff489cae3e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=bcd808832e#bcd808832ed11af340f9a8b24f89bef07c4f125a"
 dependencies = [
  "borsh",
  "derive_more",
@@ -2193,7 +2193,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler"
 version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=4463366e65#4463366e651c0d88dd2fc2923a1b6fff489cae3e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=bcd808832e#bcd808832ed11af340f9a8b24f89bef07c4f125a"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -2208,7 +2208,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler-types"
 version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=4463366e65#4463366e651c0d88dd2fc2923a1b6fff489cae3e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=bcd808832e#bcd808832ed11af340f9a8b24f89bef07c4f125a"
 dependencies = [
  "borsh",
  "derive_more",
@@ -2230,7 +2230,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host"
 version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=4463366e65#4463366e651c0d88dd2fc2923a1b6fff489cae3e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=bcd808832e#bcd808832ed11af340f9a8b24f89bef07c4f125a"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -2248,7 +2248,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host-cosmos"
 version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=4463366e65#4463366e651c0d88dd2fc2923a1b6fff489cae3e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=bcd808832e#bcd808832ed11af340f9a8b24f89bef07c4f125a"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -2270,7 +2270,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host-types"
 version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=4463366e65#4463366e651c0d88dd2fc2923a1b6fff489cae3e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=bcd808832e#bcd808832ed11af340f9a8b24f89bef07c4f125a"
 dependencies = [
  "borsh",
  "derive_more",
@@ -2283,7 +2283,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-router"
 version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=4463366e65#4463366e651c0d88dd2fc2923a1b6fff489cae3e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=bcd808832e#bcd808832ed11af340f9a8b24f89bef07c4f125a"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -2297,7 +2297,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-router-types"
 version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=4463366e65#4463366e651c0d88dd2fc2923a1b6fff489cae3e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=bcd808832e#bcd808832ed11af340f9a8b24f89bef07c4f125a"
 dependencies = [
  "borsh",
  "derive_more",
@@ -2314,7 +2314,7 @@ dependencies = [
 [[package]]
 name = "ibc-derive"
 version = "0.6.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=4463366e65#4463366e651c0d88dd2fc2923a1b6fff489cae3e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=bcd808832e#bcd808832ed11af340f9a8b24f89bef07c4f125a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2324,7 +2324,7 @@ dependencies = [
 [[package]]
 name = "ibc-primitives"
 version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=4463366e65#4463366e651c0d88dd2fc2923a1b6fff489cae3e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=bcd808832e#bcd808832ed11af340f9a8b24f89bef07c4f125a"
 dependencies = [
  "borsh",
  "derive_more",
@@ -2340,7 +2340,7 @@ dependencies = [
 [[package]]
 name = "ibc-proto"
 version = "0.41.0"
-source = "git+https://github.com/cosmos/ibc-proto-rs.git?rev=1b1d7a9#1b1d7a94c012d2e23527c438acb2599833f0153f"
+source = "git+https://github.com/cosmos/ibc-proto-rs.git?rev=a1877a5#a1877a5b78626f7f468cf5d14ff79ae5eef068ef"
 dependencies = [
  "base64 0.21.7",
  "borsh",
@@ -2359,7 +2359,7 @@ dependencies = [
 [[package]]
 name = "ibc-query"
 version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=4463366e65#4463366e651c0d88dd2fc2923a1b6fff489cae3e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=bcd808832e#bcd808832ed11af340f9a8b24f89bef07c4f125a"
 dependencies = [
  "displaydoc",
  "ibc",
@@ -3390,6 +3390,7 @@ dependencies = [
  "lazy_static",
  "memchr",
  "parking_lot",
+ "protobuf",
  "thiserror",
 ]
 
@@ -3462,6 +3463,12 @@ checksum = "193898f59edcf43c26227dcd4c8427f00d99d61e95dcde58dabd49fa291d470e"
 dependencies = [
  "prost",
 ]
+
+[[package]]
+name = "protobuf"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "protobuf-src"
@@ -3808,7 +3815,7 @@ dependencies = [
 [[package]]
 name = "risc0-cycle-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/risc0-cycle-macros.git?rev=98948b8ee0e3edffcee7f3bd95a9d93c5c0941af#98948b8ee0e3edffcee7f3bd95a9d93c5c0941af"
+source = "git+https://github.com/Sovereign-Labs/risc0-cycle-macros.git?rev=a00d0719388bcecd51b6033721957b27ffe12843#a00d0719388bcecd51b6033721957b27ffe12843"
 dependencies = [
  "bytes",
  "risc0-zkvm",
@@ -3922,6 +3929,19 @@ checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
 dependencies = [
  "bytes",
  "rustc-hex",
+]
+
+[[package]]
+name = "rockbound"
+version = "1.0.0"
+source = "git+https://github.com/sovereign-Labs/rockbound?tag=v2.0.0#edabd23e12d75058d7ce5d92e38dcc9f66f83c53"
+dependencies = [
+ "anyhow",
+ "once_cell",
+ "prometheus",
+ "rocksdb",
+ "thiserror",
+ "tracing",
 ]
 
 [[package]]
@@ -4225,6 +4245,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-big-array"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde-json-wasm"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4473,6 +4502,7 @@ dependencies = [
  "sov-modules-api",
  "sov-state",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]
@@ -4525,7 +4555,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-client"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=e67de8#e67de8b97b2a1ae71f45ed5aeb78d7697e1b4f59"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=7e41c9b#7e41c9b67be378c4d7eeaed036b72db7f48f4c58"
 dependencies = [
  "derive_more",
  "ibc-client-tendermint",
@@ -4542,11 +4572,12 @@ dependencies = [
 [[package]]
 name = "sov-celestia-client-types"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=e67de8#e67de8b97b2a1ae71f45ed5aeb78d7697e1b4f59"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=7e41c9b#7e41c9b67be378c4d7eeaed036b72db7f48f4c58"
 dependencies = [
  "base64 0.21.7",
  "bytes",
  "derive_more",
+ "hex",
  "ibc-client-tendermint",
  "ibc-core",
  "ibc-proto",
@@ -4564,6 +4595,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "borsh",
+ "derivative",
  "jsonrpsee",
  "serde",
  "serde_json",
@@ -4600,18 +4632,18 @@ dependencies = [
  "byteorder",
  "hex",
  "jmt",
+ "rockbound",
  "rocksdb",
  "serde",
  "sov-modules-core",
  "sov-rollup-interface",
- "sov-schema-db",
  "tokio",
 ]
 
 [[package]]
 name = "sov-ibc"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=e67de8#e67de8b97b2a1ae71f45ed5aeb78d7697e1b4f59"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=7e41c9b#7e41c9b67be378c4d7eeaed036b72db7f48f4c58"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4636,12 +4668,13 @@ dependencies = [
  "sov-state",
  "thiserror",
  "time",
+ "tracing",
 ]
 
 [[package]]
 name = "sov-ibc-transfer"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=e67de8#e67de8b97b2a1ae71f45ed5aeb78d7697e1b4f59"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=7e41c9b#7e41c9b67be378c4d7eeaed036b72db7f48f4c58"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -4672,6 +4705,7 @@ dependencies = [
  "serde_json",
  "sov-modules-api",
  "sov-rollup-interface",
+ "tokio",
 ]
 
 [[package]]
@@ -4688,6 +4722,7 @@ dependencies = [
  "sha2 0.10.8",
  "sov-rollup-interface",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -4700,12 +4735,9 @@ dependencies = [
  "ed25519-dalek 2.1.1",
  "hex",
  "rand",
- "schemars",
  "serde",
  "sha2 0.10.8",
- "sov-modules-api",
  "sov-rollup-interface",
- "thiserror",
 ]
 
 [[package]]
@@ -4812,9 +4844,9 @@ name = "sov-prover-storage-manager"
 version = "0.3.0"
 dependencies = [
  "anyhow",
+ "rockbound",
  "sov-db",
  "sov-rollup-interface",
- "sov-schema-db",
  "sov-state",
  "tracing",
 ]
@@ -4838,9 +4870,7 @@ dependencies = [
  "risc0-zkvm-platform",
  "serde",
  "sha2 0.10.8",
- "sov-modules-api",
  "sov-rollup-interface",
- "thiserror",
  "tracing",
 ]
 
@@ -4856,6 +4886,7 @@ dependencies = [
  "futures",
  "hex",
  "proptest",
+ "schemars",
  "serde",
  "serde_json",
  "sha2 0.10.8",
@@ -4901,18 +4932,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sov-schema-db"
-version = "0.3.0"
-dependencies = [
- "anyhow",
- "once_cell",
- "prometheus",
- "rocksdb",
- "thiserror",
- "tracing",
-]
-
-[[package]]
 name = "sov-sequencer"
 version = "0.3.0"
 dependencies = [
@@ -4923,7 +4942,9 @@ dependencies = [
  "jsonrpsee",
  "mini-moka",
  "serde",
+ "serde_json",
  "sov-modules-api",
+ "sov-modules-stf-blueprint",
  "sov-rollup-interface",
  "sov-state",
  "tokio",
@@ -4958,6 +4979,7 @@ dependencies = [
  "hex",
  "jmt",
  "serde",
+ "serde-big-array",
  "serde_json",
  "sha2 0.10.8",
  "sov-db",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ sov-sequencer-registry          = { path = "./vendor/sovereign-sdk/module-system
 sov-modules-stf-blueprint       = { path = "./vendor/sovereign-sdk/module-system/sov-modules-stf-blueprint" }
 sov-modules-rollup-blueprint    = { path = "./vendor/sovereign-sdk/module-system/sov-modules-rollup-blueprint" }
 sov-stf-runner                  = { path = "./vendor/sovereign-sdk/full-node/sov-stf-runner" }
-sov-db                          = { path = "./vendor/sovereign-sdk/full-node/db/sov-db" }
+sov-db                          = { path = "./vendor/sovereign-sdk/full-node/sov-db" }
 sov-sequencer                   = { path = "./vendor/sovereign-sdk/full-node/sov-sequencer" }
 sov-rollup-interface            = { path = "./vendor/sovereign-sdk/rollup-interface" }
 sov-risc0-adapter               = { path = "./vendor/sovereign-sdk/adapters/risc0" }
@@ -40,8 +40,8 @@ sov-celestia-adapter            = { path = "./vendor/sovereign-sdk/adapters/cele
 sov-prover-storage-manager      = { path = "./vendor/sovereign-sdk/full-node/sov-prover-storage-manager" }
 sov-mock-zkvm                   = { path = "./vendor/sovereign-sdk/adapters/mock-zkvm" }
 
-sov-ibc                         = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "e67de8" }
-sov-ibc-transfer                = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "e67de8" }
+sov-ibc                         = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "7e41c9b" }
+sov-ibc-transfer                = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "7e41c9b" }
 
 stf-starter = { path = "./crates/stf" }
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ $ make clean-db
 
 #### 3. Start the rollup node:
 
+```sh,test-ci
+export SOV_PROVER_MODE=execute 
+```
+
 This will compile and start the rollup node:
 
 ```shell,test-ci,bashtestmd:long-running,bashtestmd:wait-until=RPC
@@ -125,3 +129,11 @@ $ make test-bank-supply-of
 $ curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"bank_supplyOf","params":{"token_address":"sov1zdwj8thgev2u3yyrrlekmvtsz4av4tp3m7dm5mx5peejnesga27svq9m72"},"id":1}' http://127.0.0.1:12345
 {"jsonrpc":"2.0","result":{"amount":1000},"id":1}
 ```
+
+## Enabling the prover
+By default, demo-rollup disables proving (i.e. the default behavior is. If we want to enable proving, several options are available:
+
+* `export SOV_PROVER_MODE=skip` Skips verification logic.
+* `export SOV_PROVER_MODE=simulate` Run the rollup verification logic inside the current process.
+* `export SOV_PROVER_MODE=execute` Run the rollup verifier in a zkVM executor.
+* `export SOV_PROVER_MODE=prove` Run the rollup verifier and create a SNARK of execution.

--- a/celestia_rollup_config.toml
+++ b/celestia_rollup_config.toml
@@ -1,6 +1,6 @@
 [da]
 # The JWT used to authenticate with the celestia light client. Instructions for generating this token can be found in the README
-celestia_rpc_auth_token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJBbGxvdyI6WyJwdWJsaWMiLCJyZWFkIiwid3JpdGUiLCJhZG1pbiJdfQ.cpgAm8Hms_DYhpaQADyWll5RP13nfTAsYROrfFilpLk"
+celestia_rpc_auth_token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJBbGxvdyI6WyJwdWJsaWMiLCJyZWFkIiwid3JpdGUiLCJhZG1pbiJdfQ.1d0ZqV4B9qiTI5YtPe6WVyEJrk4dqFr160K1hr8m8oI"
 # The address of the *trusted* Celestia light client to interact with
 celestia_rpc_address = "http://127.0.0.1:26658"
 # The largest response the rollup will accept from the Celestia node. Defaults to 100 MB
@@ -15,7 +15,7 @@ path = "../../rollup-starter-data"
 # We define the rollup's genesis to occur at block number `start_height`. The rollup will ignore
 # any blocks before this height
 [runner]
-start_height = 3
+genesis_height = 3
 da_polling_interval_ms = 1000
 
 [runner.rpc_config]

--- a/celestia_rollup_config.toml
+++ b/celestia_rollup_config.toml
@@ -1,6 +1,6 @@
 [da]
 # The JWT used to authenticate with the celestia light client. Instructions for generating this token can be found in the README
-celestia_rpc_auth_token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJBbGxvdyI6WyJwdWJsaWMiLCJyZWFkIiwid3JpdGUiLCJhZG1pbiJdfQ.1d0ZqV4B9qiTI5YtPe6WVyEJrk4dqFr160K1hr8m8oI"
+celestia_rpc_auth_token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJBbGxvdyI6WyJwdWJsaWMiLCJyZWFkIiwid3JpdGUiLCJhZG1pbiJdfQ.Qysvnw7v_rFxyvX-5G4PFK9AiUAgYjteITxHfRtjycM"
 # The address of the *trusted* Celestia light client to interact with
 celestia_rpc_address = "http://127.0.0.1:26658"
 # The largest response the rollup will accept from the Celestia node. Defaults to 100 MB

--- a/crates/provers/risc0/guest-celestia/Cargo.lock
+++ b/crates/provers/risc0/guest-celestia/Cargo.lock
@@ -1093,7 +1093,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer"
 version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=4463366e65#4463366e651c0d88dd2fc2923a1b6fff489cae3e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=bcd808832e#bcd808832ed11af340f9a8b24f89bef07c4f125a"
 dependencies = [
  "ibc-app-transfer-types",
  "ibc-core",
@@ -1103,7 +1103,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer-types"
 version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=4463366e65#4463366e651c0d88dd2fc2923a1b6fff489cae3e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=bcd808832e#bcd808832ed11af340f9a8b24f89bef07c4f125a"
 dependencies = [
  "borsh",
  "derive_more",
@@ -1119,7 +1119,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint"
 version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=4463366e65#4463366e651c0d88dd2fc2923a1b6fff489cae3e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=bcd808832e#bcd808832ed11af340f9a8b24f89bef07c4f125a"
 dependencies = [
  "derive_more",
  "ibc-client-tendermint-types",
@@ -1136,7 +1136,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint-types"
 version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=4463366e65#4463366e651c0d88dd2fc2923a1b6fff489cae3e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=bcd808832e#bcd808832ed11af340f9a8b24f89bef07c4f125a"
 dependencies = [
  "displaydoc",
  "ibc-core-client-types",
@@ -1153,7 +1153,7 @@ dependencies = [
 [[package]]
 name = "ibc-core"
 version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=4463366e65#4463366e651c0d88dd2fc2923a1b6fff489cae3e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=bcd808832e#bcd808832ed11af340f9a8b24f89bef07c4f125a"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -1169,7 +1169,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel"
 version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=4463366e65#4463366e651c0d88dd2fc2923a1b6fff489cae3e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=bcd808832e#bcd808832ed11af340f9a8b24f89bef07c4f125a"
 dependencies = [
  "ibc-core-channel-types",
  "ibc-core-client",
@@ -1184,7 +1184,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel-types"
 version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=4463366e65#4463366e651c0d88dd2fc2923a1b6fff489cae3e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=bcd808832e#bcd808832ed11af340f9a8b24f89bef07c4f125a"
 dependencies = [
  "borsh",
  "derive_more",
@@ -1205,7 +1205,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client"
 version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=4463366e65#4463366e651c0d88dd2fc2923a1b6fff489cae3e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=bcd808832e#bcd808832ed11af340f9a8b24f89bef07c4f125a"
 dependencies = [
  "ibc-core-client-context",
  "ibc-core-client-types",
@@ -1218,7 +1218,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-context"
 version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=4463366e65#4463366e651c0d88dd2fc2923a1b6fff489cae3e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=bcd808832e#bcd808832ed11af340f9a8b24f89bef07c4f125a"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1234,7 +1234,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-types"
 version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=4463366e65#4463366e651c0d88dd2fc2923a1b6fff489cae3e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=bcd808832e#bcd808832ed11af340f9a8b24f89bef07c4f125a"
 dependencies = [
  "borsh",
  "derive_more",
@@ -1252,7 +1252,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-commitment-types"
 version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=4463366e65#4463366e651c0d88dd2fc2923a1b6fff489cae3e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=bcd808832e#bcd808832ed11af340f9a8b24f89bef07c4f125a"
 dependencies = [
  "borsh",
  "derive_more",
@@ -1268,7 +1268,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-connection"
 version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=4463366e65#4463366e651c0d88dd2fc2923a1b6fff489cae3e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=bcd808832e#bcd808832ed11af340f9a8b24f89bef07c4f125a"
 dependencies = [
  "ibc-core-client",
  "ibc-core-connection-types",
@@ -1280,7 +1280,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-connection-types"
 version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=4463366e65#4463366e651c0d88dd2fc2923a1b6fff489cae3e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=bcd808832e#bcd808832ed11af340f9a8b24f89bef07c4f125a"
 dependencies = [
  "borsh",
  "derive_more",
@@ -1299,7 +1299,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler"
 version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=4463366e65#4463366e651c0d88dd2fc2923a1b6fff489cae3e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=bcd808832e#bcd808832ed11af340f9a8b24f89bef07c4f125a"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -1314,7 +1314,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler-types"
 version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=4463366e65#4463366e651c0d88dd2fc2923a1b6fff489cae3e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=bcd808832e#bcd808832ed11af340f9a8b24f89bef07c4f125a"
 dependencies = [
  "borsh",
  "derive_more",
@@ -1336,7 +1336,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host"
 version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=4463366e65#4463366e651c0d88dd2fc2923a1b6fff489cae3e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=bcd808832e#bcd808832ed11af340f9a8b24f89bef07c4f125a"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1354,7 +1354,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host-types"
 version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=4463366e65#4463366e651c0d88dd2fc2923a1b6fff489cae3e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=bcd808832e#bcd808832ed11af340f9a8b24f89bef07c4f125a"
 dependencies = [
  "borsh",
  "derive_more",
@@ -1367,7 +1367,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-router"
 version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=4463366e65#4463366e651c0d88dd2fc2923a1b6fff489cae3e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=bcd808832e#bcd808832ed11af340f9a8b24f89bef07c4f125a"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1381,7 +1381,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-router-types"
 version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=4463366e65#4463366e651c0d88dd2fc2923a1b6fff489cae3e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=bcd808832e#bcd808832ed11af340f9a8b24f89bef07c4f125a"
 dependencies = [
  "borsh",
  "derive_more",
@@ -1398,7 +1398,7 @@ dependencies = [
 [[package]]
 name = "ibc-derive"
 version = "0.6.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=4463366e65#4463366e651c0d88dd2fc2923a1b6fff489cae3e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=bcd808832e#bcd808832ed11af340f9a8b24f89bef07c4f125a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1408,7 +1408,7 @@ dependencies = [
 [[package]]
 name = "ibc-primitives"
 version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=4463366e65#4463366e651c0d88dd2fc2923a1b6fff489cae3e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=bcd808832e#bcd808832ed11af340f9a8b24f89bef07c4f125a"
 dependencies = [
  "borsh",
  "derive_more",
@@ -1424,7 +1424,7 @@ dependencies = [
 [[package]]
 name = "ibc-proto"
 version = "0.41.0"
-source = "git+https://github.com/cosmos/ibc-proto-rs.git?rev=1b1d7a9#1b1d7a94c012d2e23527c438acb2599833f0153f"
+source = "git+https://github.com/cosmos/ibc-proto-rs.git?rev=a1877a5#a1877a5b78626f7f468cf5d14ff79ae5eef068ef"
 dependencies = [
  "base64",
  "borsh",
@@ -2144,7 +2144,7 @@ dependencies = [
 [[package]]
 name = "risc0-cycle-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/risc0-cycle-macros.git?rev=98948b8ee0e3edffcee7f3bd95a9d93c5c0941af#98948b8ee0e3edffcee7f3bd95a9d93c5c0941af"
+source = "git+https://github.com/Sovereign-Labs/risc0-cycle-macros.git?rev=a00d0719388bcecd51b6033721957b27ffe12843#a00d0719388bcecd51b6033721957b27ffe12843"
 dependencies = [
  "bytes",
  "risc0-zkvm",
@@ -2369,6 +2369,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-big-array"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde-json-wasm"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2503,6 +2512,7 @@ dependencies = [
  "sov-modules-api",
  "sov-state",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]
@@ -2546,7 +2556,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-client"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=e67de8#e67de8b97b2a1ae71f45ed5aeb78d7697e1b4f59"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=7e41c9b#7e41c9b67be378c4d7eeaed036b72db7f48f4c58"
 dependencies = [
  "derive_more",
  "ibc-client-tendermint",
@@ -2563,11 +2573,12 @@ dependencies = [
 [[package]]
 name = "sov-celestia-client-types"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=e67de8#e67de8b97b2a1ae71f45ed5aeb78d7697e1b4f59"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=7e41c9b#7e41c9b67be378c4d7eeaed036b72db7f48f4c58"
 dependencies = [
  "base64",
  "bytes",
  "derive_more",
+ "hex",
  "ibc-client-tendermint",
  "ibc-core",
  "ibc-proto",
@@ -2585,6 +2596,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "borsh",
+ "derivative",
  "serde",
  "sov-modules-api",
  "sov-state",
@@ -2612,7 +2624,7 @@ dependencies = [
 [[package]]
 name = "sov-ibc"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=e67de8#e67de8b97b2a1ae71f45ed5aeb78d7697e1b4f59"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=7e41c9b#7e41c9b67be378c4d7eeaed036b72db7f48f4c58"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2634,12 +2646,13 @@ dependencies = [
  "sov-state",
  "thiserror",
  "time",
+ "tracing",
 ]
 
 [[package]]
 name = "sov-ibc-transfer"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=e67de8#e67de8b97b2a1ae71f45ed5aeb78d7697e1b4f59"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=7e41c9b#7e41c9b67be378c4d7eeaed036b72db7f48f4c58"
 dependencies = [
  "anyhow",
  "base64",
@@ -2668,6 +2681,7 @@ dependencies = [
  "serde",
  "sha2 0.10.8",
  "sov-rollup-interface",
+ "tracing",
 ]
 
 [[package]]
@@ -2757,7 +2771,6 @@ dependencies = [
  "serde",
  "sha2 0.10.8",
  "sov-rollup-interface",
- "thiserror",
  "tracing",
 ]
 
@@ -2802,6 +2815,7 @@ dependencies = [
  "hex",
  "jmt",
  "serde",
+ "serde-big-array",
  "serde_json",
  "sha2 0.10.8",
  "sov-modules-core",

--- a/crates/provers/risc0/guest-mock/Cargo.lock
+++ b/crates/provers/risc0/guest-mock/Cargo.lock
@@ -834,7 +834,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer"
 version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=4463366e65#4463366e651c0d88dd2fc2923a1b6fff489cae3e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=bcd808832e#bcd808832ed11af340f9a8b24f89bef07c4f125a"
 dependencies = [
  "ibc-app-transfer-types",
  "ibc-core",
@@ -844,7 +844,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer-types"
 version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=4463366e65#4463366e651c0d88dd2fc2923a1b6fff489cae3e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=bcd808832e#bcd808832ed11af340f9a8b24f89bef07c4f125a"
 dependencies = [
  "borsh",
  "derive_more",
@@ -860,7 +860,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint"
 version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=4463366e65#4463366e651c0d88dd2fc2923a1b6fff489cae3e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=bcd808832e#bcd808832ed11af340f9a8b24f89bef07c4f125a"
 dependencies = [
  "derive_more",
  "ibc-client-tendermint-types",
@@ -877,7 +877,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint-types"
 version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=4463366e65#4463366e651c0d88dd2fc2923a1b6fff489cae3e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=bcd808832e#bcd808832ed11af340f9a8b24f89bef07c4f125a"
 dependencies = [
  "displaydoc",
  "ibc-core-client-types",
@@ -894,7 +894,7 @@ dependencies = [
 [[package]]
 name = "ibc-core"
 version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=4463366e65#4463366e651c0d88dd2fc2923a1b6fff489cae3e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=bcd808832e#bcd808832ed11af340f9a8b24f89bef07c4f125a"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -910,7 +910,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel"
 version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=4463366e65#4463366e651c0d88dd2fc2923a1b6fff489cae3e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=bcd808832e#bcd808832ed11af340f9a8b24f89bef07c4f125a"
 dependencies = [
  "ibc-core-channel-types",
  "ibc-core-client",
@@ -925,7 +925,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel-types"
 version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=4463366e65#4463366e651c0d88dd2fc2923a1b6fff489cae3e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=bcd808832e#bcd808832ed11af340f9a8b24f89bef07c4f125a"
 dependencies = [
  "borsh",
  "derive_more",
@@ -946,7 +946,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client"
 version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=4463366e65#4463366e651c0d88dd2fc2923a1b6fff489cae3e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=bcd808832e#bcd808832ed11af340f9a8b24f89bef07c4f125a"
 dependencies = [
  "ibc-core-client-context",
  "ibc-core-client-types",
@@ -959,7 +959,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-context"
 version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=4463366e65#4463366e651c0d88dd2fc2923a1b6fff489cae3e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=bcd808832e#bcd808832ed11af340f9a8b24f89bef07c4f125a"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -975,7 +975,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-types"
 version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=4463366e65#4463366e651c0d88dd2fc2923a1b6fff489cae3e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=bcd808832e#bcd808832ed11af340f9a8b24f89bef07c4f125a"
 dependencies = [
  "borsh",
  "derive_more",
@@ -993,7 +993,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-commitment-types"
 version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=4463366e65#4463366e651c0d88dd2fc2923a1b6fff489cae3e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=bcd808832e#bcd808832ed11af340f9a8b24f89bef07c4f125a"
 dependencies = [
  "borsh",
  "derive_more",
@@ -1009,7 +1009,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-connection"
 version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=4463366e65#4463366e651c0d88dd2fc2923a1b6fff489cae3e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=bcd808832e#bcd808832ed11af340f9a8b24f89bef07c4f125a"
 dependencies = [
  "ibc-core-client",
  "ibc-core-connection-types",
@@ -1021,7 +1021,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-connection-types"
 version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=4463366e65#4463366e651c0d88dd2fc2923a1b6fff489cae3e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=bcd808832e#bcd808832ed11af340f9a8b24f89bef07c4f125a"
 dependencies = [
  "borsh",
  "derive_more",
@@ -1040,7 +1040,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler"
 version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=4463366e65#4463366e651c0d88dd2fc2923a1b6fff489cae3e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=bcd808832e#bcd808832ed11af340f9a8b24f89bef07c4f125a"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -1055,7 +1055,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler-types"
 version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=4463366e65#4463366e651c0d88dd2fc2923a1b6fff489cae3e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=bcd808832e#bcd808832ed11af340f9a8b24f89bef07c4f125a"
 dependencies = [
  "borsh",
  "derive_more",
@@ -1077,7 +1077,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host"
 version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=4463366e65#4463366e651c0d88dd2fc2923a1b6fff489cae3e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=bcd808832e#bcd808832ed11af340f9a8b24f89bef07c4f125a"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1095,7 +1095,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host-types"
 version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=4463366e65#4463366e651c0d88dd2fc2923a1b6fff489cae3e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=bcd808832e#bcd808832ed11af340f9a8b24f89bef07c4f125a"
 dependencies = [
  "borsh",
  "derive_more",
@@ -1108,7 +1108,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-router"
 version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=4463366e65#4463366e651c0d88dd2fc2923a1b6fff489cae3e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=bcd808832e#bcd808832ed11af340f9a8b24f89bef07c4f125a"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1122,7 +1122,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-router-types"
 version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=4463366e65#4463366e651c0d88dd2fc2923a1b6fff489cae3e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=bcd808832e#bcd808832ed11af340f9a8b24f89bef07c4f125a"
 dependencies = [
  "borsh",
  "derive_more",
@@ -1139,7 +1139,7 @@ dependencies = [
 [[package]]
 name = "ibc-derive"
 version = "0.6.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=4463366e65#4463366e651c0d88dd2fc2923a1b6fff489cae3e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=bcd808832e#bcd808832ed11af340f9a8b24f89bef07c4f125a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1149,7 +1149,7 @@ dependencies = [
 [[package]]
 name = "ibc-primitives"
 version = "0.50.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=4463366e65#4463366e651c0d88dd2fc2923a1b6fff489cae3e"
+source = "git+https://github.com/cosmos/ibc-rs.git?rev=bcd808832e#bcd808832ed11af340f9a8b24f89bef07c4f125a"
 dependencies = [
  "borsh",
  "derive_more",
@@ -1165,7 +1165,7 @@ dependencies = [
 [[package]]
 name = "ibc-proto"
 version = "0.41.0"
-source = "git+https://github.com/cosmos/ibc-proto-rs.git?rev=1b1d7a9#1b1d7a94c012d2e23527c438acb2599833f0153f"
+source = "git+https://github.com/cosmos/ibc-proto-rs.git?rev=a1877a5#a1877a5b78626f7f468cf5d14ff79ae5eef068ef"
 dependencies = [
  "base64",
  "borsh",
@@ -1695,7 +1695,7 @@ dependencies = [
 [[package]]
 name = "risc0-cycle-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/risc0-cycle-macros.git?rev=98948b8ee0e3edffcee7f3bd95a9d93c5c0941af#98948b8ee0e3edffcee7f3bd95a9d93c5c0941af"
+source = "git+https://github.com/Sovereign-Labs/risc0-cycle-macros.git?rev=a00d0719388bcecd51b6033721957b27ffe12843#a00d0719388bcecd51b6033721957b27ffe12843"
 dependencies = [
  "bytes",
  "risc0-zkvm",
@@ -1834,6 +1834,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-big-array"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde-json-wasm"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1968,6 +1977,7 @@ dependencies = [
  "sov-modules-api",
  "sov-state",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]
@@ -1989,7 +1999,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-client"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=e67de8#e67de8b97b2a1ae71f45ed5aeb78d7697e1b4f59"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=7e41c9b#7e41c9b67be378c4d7eeaed036b72db7f48f4c58"
 dependencies = [
  "derive_more",
  "ibc-client-tendermint",
@@ -2006,11 +2016,12 @@ dependencies = [
 [[package]]
 name = "sov-celestia-client-types"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=e67de8#e67de8b97b2a1ae71f45ed5aeb78d7697e1b4f59"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=7e41c9b#7e41c9b67be378c4d7eeaed036b72db7f48f4c58"
 dependencies = [
  "base64",
  "bytes",
  "derive_more",
+ "hex",
  "ibc-client-tendermint",
  "ibc-core",
  "ibc-proto",
@@ -2028,6 +2039,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "borsh",
+ "derivative",
  "serde",
  "sov-modules-api",
  "sov-state",
@@ -2037,7 +2049,7 @@ dependencies = [
 [[package]]
 name = "sov-ibc"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=e67de8#e67de8b97b2a1ae71f45ed5aeb78d7697e1b4f59"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=7e41c9b#7e41c9b67be378c4d7eeaed036b72db7f48f4c58"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2059,12 +2071,13 @@ dependencies = [
  "sov-state",
  "thiserror",
  "time",
+ "tracing",
 ]
 
 [[package]]
 name = "sov-ibc-transfer"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=e67de8#e67de8b97b2a1ae71f45ed5aeb78d7697e1b4f59"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=7e41c9b#7e41c9b67be378c4d7eeaed036b72db7f48f4c58"
 dependencies = [
  "anyhow",
  "base64",
@@ -2093,6 +2106,7 @@ dependencies = [
  "serde",
  "sha2 0.10.8",
  "sov-rollup-interface",
+ "tracing",
 ]
 
 [[package]]
@@ -2182,7 +2196,6 @@ dependencies = [
  "serde",
  "sha2 0.10.8",
  "sov-rollup-interface",
- "thiserror",
  "tracing",
 ]
 
@@ -2227,6 +2240,7 @@ dependencies = [
  "hex",
  "jmt",
  "serde",
+ "serde-big-array",
  "serde_json",
  "sha2 0.10.8",
  "sov-modules-core",

--- a/crates/rollup/Cargo.toml
+++ b/crates/rollup/Cargo.toml
@@ -41,14 +41,14 @@ tokio = { workspace = true }
 
 risc0-starter = { path = "../provers/risc0" }
 stf-starter = { path = "../stf", features = ["native"] }
-sov-risc0-adapter = { workspace = true, features = ["native", "sov-modules"] }
+sov-risc0-adapter = { workspace = true, features = ["native"] }
 
 # binary dependencies
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 
 [dev-dependencies]
 tempfile = { workspace = true }
-sov-mock-zkvm = { workspace = true, features = ["native", "sov-modules"] }
+sov-mock-zkvm = { workspace = true, features = ["native"] }
 
 [features]
 default = ["mock_da"] # set mock_da as the default feature

--- a/crates/rollup/src/bin/node.rs
+++ b/crates/rollup/src/bin/node.rs
@@ -67,13 +67,32 @@ async fn main() -> Result<(), anyhow::Error> {
     let genesis_paths = args.genesis_paths.as_str();
     let kernel_genesis_paths = args.kernel_genesis_paths.as_str();
 
+    let prover_config = if option_env!("CI").is_some() {
+        Some(RollupProverConfig::Execute)
+    } else if let Some(prover) = option_env!("SOV_PROVER_MODE") {
+        match prover {
+            "simulate" => Some(RollupProverConfig::Simulate),
+            "execute" => Some(RollupProverConfig::Execute),
+            "prove" => Some(RollupProverConfig::Prove),
+            _ => {
+                tracing::warn!(
+                    prover_mode = prover,
+                    "Unknown sov prover mode, using 'Skip' default"
+                );
+                Some(RollupProverConfig::Skip)
+            }
+        }
+    } else {
+        None
+    };
+
     let rollup = new_rollup(
         &GenesisPaths::from_dir(genesis_paths),
         &BasicKernelGenesisPaths {
             chain_state: kernel_genesis_paths.into(),
         },
         rollup_config_path,
-        RollupProverConfig::Execute,
+        prover_config,
     )
     .await?;
     rollup.run().await
@@ -84,7 +103,7 @@ async fn new_rollup(
     rt_genesis_paths: &GenesisPaths,
     kernel_genesis_paths: &BasicKernelGenesisPaths,
     rollup_config_path: &str,
-    prover_config: RollupProverConfig,
+    prover_config: Option<RollupProverConfig>,
 ) -> Result<Rollup<MockRollup>, anyhow::Error> {
     info!("Reading rollup config from {rollup_config_path:?}");
 
@@ -115,7 +134,7 @@ async fn new_rollup(
     rt_genesis_paths: &GenesisPaths,
     kernel_genesis_paths: &BasicKernelGenesisPaths,
     rollup_config_path: &str,
-    prover_config: RollupProverConfig,
+    prover_config: Option<RollupProverConfig>
 ) -> Result<Rollup<CelestiaRollup>, anyhow::Error> {
     info!(
         "Starting celestia rollup with config {}",

--- a/crates/rollup/src/celestia_rollup.rs
+++ b/crates/rollup/src/celestia_rollup.rs
@@ -3,10 +3,10 @@
 
 use async_trait::async_trait;
 use sov_celestia_adapter::types::Namespace;
+use sov_celestia_adapter::verifier::address::CelestiaAddress;
 use sov_celestia_adapter::verifier::{CelestiaSpec, CelestiaVerifier, RollupParams};
 use sov_celestia_adapter::{CelestiaConfig, CelestiaService};
 use sov_modules_api::default_spec::{DefaultSpec, ZkDefaultSpec};
-use sov_modules_api::Address;
 use sov_modules_api::Spec;
 use sov_modules_rollup_blueprint::RollupBlueprint;
 use sov_modules_stf_blueprint::kernels::basic::BasicKernel;
@@ -14,6 +14,7 @@ use sov_modules_stf_blueprint::StfBlueprint;
 use sov_prover_storage_manager::ProverStorageManager;
 use sov_risc0_adapter::host::Risc0Host;
 use sov_risc0_adapter::Risc0Verifier;
+use sov_rollup_interface::zk::aggregated_proof::CodeCommitment;
 use sov_rollup_interface::zk::{ZkvmGuest, ZkvmHost};
 use sov_state::config::Config as StorageConfig;
 use sov_state::Storage;
@@ -21,6 +22,7 @@ use sov_state::{DefaultStorageSpec, ZkStorage};
 use sov_stf_runner::ParallelProverService;
 use sov_stf_runner::RollupConfig;
 use sov_stf_runner::RollupProverConfig;
+use std::str::FromStr;
 use std::sync::{Arc, RwLock};
 use stf_starter::Runtime;
 
@@ -77,7 +79,8 @@ impl RollupBlueprint for CelestiaRollup {
         da_service: &Self::DaService,
     ) -> Result<jsonrpsee::RpcModule<()>, anyhow::Error> {
         // TODO set the sequencer address
-        let sequencer = Address::new([0; 32]);
+        let sequencer =
+            CelestiaAddress::from_str("celestia1a68m2l85zn5xh0l07clk4rfvnezhywc53g8x7s")?;
 
         #[allow(unused_mut)]
         let mut rpc_methods = sov_modules_rollup_blueprint::register_rpc::<
@@ -131,6 +134,7 @@ impl RollupBlueprint for CelestiaRollup {
             prover_config,
             zk_storage,
             rollup_config.prover_service,
+            CodeCommitment::default(),
         )
     }
 

--- a/crates/rollup/src/mock_rollup.rs
+++ b/crates/rollup/src/mock_rollup.rs
@@ -5,9 +5,8 @@ use std::sync::{Arc, RwLock};
 
 use async_trait::async_trait;
 use sov_db::ledger_db::LedgerDB;
-use sov_mock_da::{MockDaConfig, MockDaService, MockDaSpec};
+use sov_mock_da::{MockAddress, MockDaConfig, MockDaService, MockDaSpec};
 use sov_modules_api::default_spec::{DefaultSpec, ZkDefaultSpec};
-use sov_modules_api::Address;
 use sov_modules_api::Spec;
 use sov_modules_rollup_blueprint::RollupBlueprint;
 use sov_modules_stf_blueprint::kernels::basic::BasicKernel;
@@ -15,7 +14,7 @@ use sov_modules_stf_blueprint::StfBlueprint;
 use sov_prover_storage_manager::ProverStorageManager;
 use sov_risc0_adapter::host::Risc0Host;
 use sov_risc0_adapter::Risc0Verifier;
-use sov_rollup_interface::zk::{ZkvmGuest, ZkvmHost};
+use sov_rollup_interface::zk::{ZkvmGuest, ZkvmHost, aggregated_proof::CodeCommitment};
 use sov_state::config::Config as StorageConfig;
 use sov_state::Storage;
 use sov_state::{DefaultStorageSpec, ZkStorage};
@@ -80,7 +79,7 @@ impl RollupBlueprint for MockRollup {
         da_service: &Self::DaService,
     ) -> Result<jsonrpsee::RpcModule<()>, anyhow::Error> {
         // TODO set the sequencer address
-        let sequencer = Address::new([0; 32]);
+        let sequencer = MockAddress::new([0; 32]);
 
         #[allow(unused_mut)]
         let mut rpc_methods = sov_modules_rollup_blueprint::register_rpc::<
@@ -124,6 +123,7 @@ impl RollupBlueprint for MockRollup {
             prover_config,
             zk_storage,
             rollup_config.prover_service,
+            CodeCommitment::default()
         )
     }
 

--- a/crates/rollup/tests/bank/mod.rs
+++ b/crates/rollup/tests/bank/mod.rs
@@ -4,7 +4,7 @@ use super::test_helpers::start_rollup;
 use borsh::BorshSerialize;
 use jsonrpsee::core::client::{Subscription, SubscriptionClientT};
 use jsonrpsee::rpc_params;
-use sov_mock_da::MockDaSpec;
+use sov_mock_da::{MockAddress, MockDaConfig, MockDaSpec};
 use sov_modules_api::transaction::Transaction;
 use sov_modules_api::{CryptoSpec, PrivateKey, Spec};
 use sov_modules_stf_blueprint::kernels::basic::BasicKernelGenesisPaths;
@@ -16,8 +16,8 @@ use stf_starter::RuntimeCall;
 const TOKEN_SALT: u64 = 0;
 const TOKEN_NAME: &str = "test_token";
 
-type DefaultSpec = sov_modules_api::default_spec::DefaultSpec<sov_mock_zkvm::MockZkVerifier>;
-type DefaultPrivateKey = <<DefaultSpec as Spec>::CryptoSpec as CryptoSpec>::PrivateKey;
+type TestSpec = sov_modules_api::default_spec::DefaultSpec<sov_mock_zkvm::MockZkVerifier>;
+type DefaultPrivateKey = <<TestSpec as Spec>::CryptoSpec as CryptoSpec>::PrivateKey;
 
 #[tokio::test]
 async fn bank_tx_tests() -> Result<(), anyhow::Error> {
@@ -30,11 +30,15 @@ async fn bank_tx_tests() -> Result<(), anyhow::Error> {
             BasicKernelGenesisPaths {
                 chain_state: "../../test-data/genesis/mock/chain_state.json".into(),
             },
-            RollupProverConfig::Execute,
+            RollupProverConfig::Skip,
+            MockDaConfig {
+                sender_address: MockAddress::new([0; 32]),
+                finalization_blocks: 3,
+                wait_attempts: 10,
+            },
         )
         .await;
     });
-
     let port = port_rx.await.unwrap();
 
     // If the rollup throws an error, return it and stop trying to send the transaction
@@ -47,26 +51,25 @@ async fn bank_tx_tests() -> Result<(), anyhow::Error> {
 
 async fn send_test_create_token_tx(rpc_address: SocketAddr) -> Result<(), anyhow::Error> {
     let key = DefaultPrivateKey::generate();
-    let user_address: <DefaultSpec as Spec>::Address = key.to_address();
+    let user_address: <TestSpec as Spec>::Address = key.to_address();
 
     let token_address =
-        sov_bank::get_token_address::<DefaultSpec>(TOKEN_NAME, &user_address, TOKEN_SALT);
+        sov_bank::get_token_address::<TestSpec>(TOKEN_NAME, &user_address, TOKEN_SALT);
 
-    let msg = RuntimeCall::<DefaultSpec, MockDaSpec>::bank(
-        sov_bank::CallMessage::<DefaultSpec>::CreateToken {
+    let msg =
+        RuntimeCall::<TestSpec, MockDaSpec>::bank(sov_bank::CallMessage::<TestSpec>::CreateToken {
             salt: TOKEN_SALT,
             token_name: TOKEN_NAME.to_string(),
             initial_balance: 1000,
             minter_address: user_address,
             authorized_minters: vec![],
-        },
-    );
+        });
     let chain_id = 0;
     let gas_tip = 0;
     let gas_limit = 0;
     let nonce = 0;
     let max_gas_price = None;
-    let tx = Transaction::<DefaultSpec>::new_signed_tx(
+    let tx = Transaction::<TestSpec>::new_signed_tx(
         &key,
         msg.try_to_vec().unwrap(),
         chain_id,
@@ -88,12 +91,11 @@ async fn send_test_create_token_tx(rpc_address: SocketAddr) -> Result<(), anyhow
         )
         .await?;
 
-    client.send_transaction(tx).await?;
-
+    client.send_transactions(vec![tx], None).await.unwrap();
     // Wait until the rollup has processed the next slot
     let _ = slot_processed_subscription.next().await;
 
-    let balance_response = sov_bank::BankRpcClient::<DefaultSpec>::balance_of(
+    let balance_response = sov_bank::BankRpcClient::<TestSpec>::balance_of(
         client.http(),
         None,
         user_address,

--- a/crates/rollup/tests/test_helpers.rs
+++ b/crates/rollup/tests/test_helpers.rs
@@ -1,6 +1,6 @@
 use std::net::SocketAddr;
 
-use sov_mock_da::{MockAddress, MockDaConfig};
+use sov_mock_da::MockDaConfig;
 use sov_modules_rollup_blueprint::RollupBlueprint;
 use sov_modules_stf_blueprint::kernels::basic::BasicKernelGenesisConfig;
 use sov_modules_stf_blueprint::kernels::basic::BasicKernelGenesisPaths;
@@ -16,6 +16,7 @@ pub async fn start_rollup(
     rt_genesis_paths: GenesisPaths,
     kernel_genesis_paths: BasicKernelGenesisPaths,
     rollup_prover_config: RollupProverConfig,
+    da_config: MockDaConfig,
 ) {
     let temp_dir = tempfile::tempdir().unwrap();
     let temp_path = temp_dir.path();
@@ -25,24 +26,20 @@ pub async fn start_rollup(
             path: temp_path.to_path_buf(),
         },
         runner: RunnerConfig {
-            start_height: 1,
+            genesis_height: 0,
+            da_polling_interval_ms: 1000,
             rpc_config: RpcConfig {
                 bind_host: "127.0.0.1".into(),
                 bind_port: 0,
             },
-            da_polling_interval_ms: 100,
         },
-        da: MockDaConfig {
-            sender_address: MockAddress::from([0; 32]),
-            finalization_blocks: 0,
-            wait_attempts: 1000,
-        },
+        da: da_config,
         prover_service: ProverServiceConfig {
             aggregated_proof_block_jump: 1,
         },
     };
 
-    let mock_rollup = MockRollup {};
+    let mock_demo_rollup = MockRollup {};
 
     let kernel_genesis = BasicKernelGenesisConfig {
         chain_state: serde_json::from_str(
@@ -52,15 +49,16 @@ pub async fn start_rollup(
         .expect("Failed to parse chain_state genesis config"),
     };
 
-    let rollup = mock_rollup
+    let rollup = mock_demo_rollup
         .create_new_rollup(
             &rt_genesis_paths,
             kernel_genesis,
             rollup_config,
-            rollup_prover_config,
+            Some(rollup_prover_config),
         )
         .await
         .unwrap();
+
     rollup
         .run_and_report_rpc_port(Some(rpc_reporting_channel))
         .await

--- a/crates/stf/src/hooks.rs
+++ b/crates/stf/src/hooks.rs
@@ -17,7 +17,6 @@ use sov_modules_api::{
 };
 use sov_modules_stf_blueprint::SequencerOutcome;
 use sov_sequencer_registry::SequencerRegistry;
-use sov_state::Storage;
 use tracing::info;
 
 impl<S: Spec, Da: DaSpec> GasEnforcer<S, Da> for Runtime<S, Da> {
@@ -180,11 +179,12 @@ impl<S: Spec, Da: DaSpec> ApplyBatchHooks<Da> for Runtime<S, Da> {
 
 impl<S: Spec, Da: DaSpec> SlotHooks for Runtime<S, Da> {
     type Spec = S;
-
     fn begin_slot_hook(
         &self,
-        _pre_state_root: &<<Self::Spec as Spec>::Storage as Storage>::Root,
-        _versioned_working_set: &mut sov_modules_api::VersionedStateReadWriter<StateCheckpoint<S>>,
+        _pre_state_root: <Self::Spec as Spec>::VisibleHash,
+        _versioned_working_set: &mut sov_modules_api::VersionedStateReadWriter<
+            StateCheckpoint<Self::Spec>,
+        >,
     ) {
     }
 
@@ -196,8 +196,8 @@ impl<S: Spec, Da: sov_modules_api::DaSpec> FinalizeHook for Runtime<S, Da> {
 
     fn finalize_hook(
         &self,
-        _root_hash: &<<Self::Spec as Spec>::Storage as Storage>::Root,
-        _accessory_working_set: &mut AccessoryStateCheckpoint<S>,
+        _root_hash: <Self::Spec as Spec>::VisibleHash,
+        _accessory_working_set: &mut AccessoryStateCheckpoint<Self::Spec>,
     ) {
     }
 }

--- a/flake.lock
+++ b/flake.lock
@@ -119,23 +119,6 @@
         "type": "github"
       }
     },
-    "risc0-cycle-macros-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1707815844,
-        "narHash": "sha256-tl6TvAUghcJvlnbD1iYH4mHjgSEtNKsAYN9ZZP69pyc=",
-        "owner": "Sovereign-Labs",
-        "repo": "risc0-cycle-macros",
-        "rev": "98948b8ee0e3edffcee7f3bd95a9d93c5c0941af",
-        "type": "github"
-      },
-      "original": {
-        "owner": "Sovereign-Labs",
-        "repo": "risc0-cycle-macros",
-        "rev": "98948b8ee0e3edffcee7f3bd95a9d93c5c0941af",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "celestia-app-src": "celestia-app-src",
@@ -143,7 +126,6 @@
         "flake-utils": "flake-utils",
         "gaia-src": "gaia-src",
         "nixpkgs": "nixpkgs",
-        "risc0-cycle-macros-src": "risc0-cycle-macros-src",
         "rust-overlay": "rust-overlay",
         "sovereign-sdk-src": "sovereign-sdk-src"
       }
@@ -170,16 +152,16 @@
     "sovereign-sdk-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1708644201,
-        "narHash": "sha256-NN1uomkyqAxRyXkAvOl809gUhwXJON0WPFe1WZAinMI=",
+        "lastModified": 1709835864,
+        "narHash": "sha256-k9jWxhyIaYYS7tFe2el3g3t323oT3JZJPpm69DEz8oM=",
         "ref": "refs/heads/nightly",
-        "rev": "5a144d60eefaf9ce166bbfd66324b959aa4ae82b",
-        "revCount": 818,
+        "rev": "3f94ceccae8f84eb191deeb97ce65a1af3c9fd1b",
+        "revCount": 859,
         "type": "git",
         "url": "ssh://git@github.com/informalsystems/sovereign-sdk-wip"
       },
       "original": {
-        "rev": "5a144d60eefaf9ce166bbfd66324b959aa4ae82b",
+        "rev": "3f94ceccae8f84eb191deeb97ce65a1af3c9fd1b",
         "type": "git",
         "url": "ssh://git@github.com/informalsystems/sovereign-sdk-wip"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -10,12 +10,7 @@
 
         sovereign-sdk-src = {
             flake = false;
-            url = git+ssh://git@github.com/informalsystems/sovereign-sdk-wip?rev=5a144d60eefaf9ce166bbfd66324b959aa4ae82b;
-        };
-
-        risc0-cycle-macros-src = {
-            flake = false;
-            url = github:Sovereign-Labs/risc0-cycle-macros?rev=98948b8ee0e3edffcee7f3bd95a9d93c5c0941af;
+            url = git+ssh://git@github.com/informalsystems/sovereign-sdk-wip?rev=3f94ceccae8f84eb191deeb97ce65a1af3c9fd1b;
         };
 
         celestia-app-src = {
@@ -61,8 +56,8 @@
                 rust-bin = nixpkgs.rust-bin.stable.latest.complete;
 
                 risc0-rust-tarball = builtins.fetchurl {
-                    url = "https://github.com/risc0/rust/releases/download/v2024-01-31.1/rust-toolchain-x86_64-unknown-linux-gnu.tar.gz";
-                    sha256 = "sha256:05k8d47zcrascjwwas9pnzg6qz5ambxvfh485flxsn6l7hxq3jf0";
+                    url = "https://github.com/risc0/rust/releases/download/v2024-02-08.1/rust-toolchain-x86_64-unknown-linux-gnu.tar.gz";
+                    sha256 = "sha256:1v4i19wpj9z2zpn2wdf7w1nw5ridwi1linzy0g93wiy09pmz64j9";
                 };
 
                 risc0-circuit = builtins.fetchurl {
@@ -76,7 +71,7 @@
 
                 rollup-packages = import ./nix/rollup.nix {
                     inherit nixpkgs rust-bin risc0-rust risc0-circuit;
-                    inherit (inputs) sovereign-sdk-src risc0-cycle-macros-src;
+                    inherit (inputs) sovereign-sdk-src;
                 };
 
                 gaia = import ./nix/gaia.nix {

--- a/nix/rollup.nix
+++ b/nix/rollup.nix
@@ -3,7 +3,6 @@
 ,   rust-bin
 ,   risc0-rust
 ,   sovereign-sdk-src
-,   risc0-cycle-macros-src
 ,   risc0-circuit
 }:
 let
@@ -16,7 +15,6 @@ let
             mkdir -p $out/crates $out/vendor
             cp -r . $out/crates
             cp -r ${sovereign-sdk-src} $out/vendor/sovereign-sdk
-            cp -r ${risc0-cycle-macros-src} $out/vendor/risc0-cycle-macros
             cp ${../Cargo.toml} $out/Cargo.toml
             cp ${../constants.json} $out/constants.json
         '';
@@ -32,7 +30,6 @@ let
             mkdir -p $out/crates $out/vendor
             cp -r . $out/crates
             cp -r ${sovereign-sdk-src} $out/vendor/sovereign-sdk
-            cp -r ${risc0-cycle-macros-src} $out/vendor/risc0-cycle-macros
             cp ${../Cargo.toml} $out/Cargo.toml
             cp ${../Cargo.lock} $out/Cargo.lock
             cp ${../constants.json} $out/constants.json
@@ -53,10 +50,10 @@ let
                 "crypto-bigint-0.5.2" = "sha256-9rh8z3vwOQ7/mtzVbyADoRWgTzARF/nkhBwfKb7+A6I=";
                 "curve25519-dalek-4.1.0" = "sha256-H8YMea3AIcUn9NGRfataNjCTzCK4NAjo4ZhWuPfT6ts=";
                 "sha2-0.10.8" = "sha256-vuFQFlbDXEW+n9+Nx2VeWanggCSd6NZ+GVEDFS9qZ2M=";
-                "ibc-app-transfer-0.50.0" = "sha256-8iWoYw9xX1D/Z+H7IVUP4AoEI4LjL3jzseAOvPBDFbU=";
-                "ibc-proto-0.41.0" = "sha256-OXqtIFDK5KdYW39EkNGGtfuDvOAMjmxzfnSpm1NWpRc=";
-                "risc0-cycle-utils-0.3.0" = "sha256-tl6TvAUghcJvlnbD1iYH4mHjgSEtNKsAYN9ZZP69pyc=";
-                "sov-celestia-client-0.1.0" = "sha256-5o3GYYXfpcqI5qyCSzIKbYmm/wj2Zs+k+6WoVctvfW0=";
+                "ibc-app-transfer-0.50.0" = "sha256-PakLJz3xIKXfW6iC4mB4KutOfAgn8jC/8t5epysZE5g=";
+                "ibc-proto-0.41.0" = "sha256-Q3JS+hAYivBZvtlgEM11qDp55d9clNztASNQE505oX8=";
+                "risc0-cycle-utils-0.3.0" = "sha256-5dA62v1eqfyZBny4s3YlC2Tty7Yfd/OAVGfTlLBgypk=";
+                "sov-celestia-client-0.1.0" = "sha256-P7Sqf9fhKaf8ZaccYiW83YImaPfefWLDF7HXSYcMQMs=";
             };
         };
 
@@ -94,14 +91,14 @@ let
                 "celestia-proto-0.1.0" = "sha256-iUgrctxdJUyhfrEQ0zoVj5AKIqgj/jQVNli5/K2nxK0=";
                 "crypto-bigint-0.5.2" = "sha256-9rh8z3vwOQ7/mtzVbyADoRWgTzARF/nkhBwfKb7+A6I=";
                 "curve25519-dalek-4.1.0" = "sha256-H8YMea3AIcUn9NGRfataNjCTzCK4NAjo4ZhWuPfT6ts=";
-                "ibc-app-transfer-0.50.0" = "sha256-8iWoYw9xX1D/Z+H7IVUP4AoEI4LjL3jzseAOvPBDFbU=";
-                "ibc-proto-0.41.0" = "sha256-OXqtIFDK5KdYW39EkNGGtfuDvOAMjmxzfnSpm1NWpRc=";
+                "ibc-app-transfer-0.50.0" = "sha256-PakLJz3xIKXfW6iC4mB4KutOfAgn8jC/8t5epysZE5g=";
+                "ibc-proto-0.41.0" = "sha256-Q3JS+hAYivBZvtlgEM11qDp55d9clNztASNQE505oX8=";
                 "jmt-0.9.0" = "sha256-pq1v6FXS//6Dh+fdysQIVp+RVLHdXrW5aDx3263O1rs=";
                 "nmt-rs-0.1.0" = "sha256-jcHbqyIKk8ZDDjSz+ot5YDxROOnrpM4TRmNFVfNniwU=";
                 "sha2-0.10.8" = "sha256-vuFQFlbDXEW+n9+Nx2VeWanggCSd6NZ+GVEDFS9qZ2M=";
-                "sov-celestia-client-0.1.0" = "sha256-5o3GYYXfpcqI5qyCSzIKbYmm/wj2Zs+k+6WoVctvfW0=";
+                "sov-celestia-client-0.1.0" = "sha256-P7Sqf9fhKaf8ZaccYiW83YImaPfefWLDF7HXSYcMQMs=";
                 "tendermint-0.32.0" = "sha256-FtY7a+hBvQryATrs3mykCWFRe8ABTT6cuf5oh9IBElQ=";
-                "risc0-cycle-utils-0.3.0" = "sha256-tl6TvAUghcJvlnbD1iYH4mHjgSEtNKsAYN9ZZP69pyc=";
+                "risc0-cycle-utils-0.3.0" = "sha256-5dA62v1eqfyZBny4s3YlC2Tty7Yfd/OAVGfTlLBgypk=";
             };
         };
 
@@ -142,10 +139,11 @@ let
                 "tendermint-0.32.0" = "sha256-FtY7a+hBvQryATrs3mykCWFRe8ABTT6cuf5oh9IBElQ=";
                 "crypto-bigint-0.5.2" = "sha256-9rh8z3vwOQ7/mtzVbyADoRWgTzARF/nkhBwfKb7+A6I=";
                 "curve25519-dalek-4.1.0" = "sha256-H8YMea3AIcUn9NGRfataNjCTzCK4NAjo4ZhWuPfT6ts=";
-                "ibc-0.50.0" = "sha256-8iWoYw9xX1D/Z+H7IVUP4AoEI4LjL3jzseAOvPBDFbU=";
-                "ibc-proto-0.41.0" = "sha256-OXqtIFDK5KdYW39EkNGGtfuDvOAMjmxzfnSpm1NWpRc=";
-                "sov-celestia-client-0.1.0" = "sha256-5o3GYYXfpcqI5qyCSzIKbYmm/wj2Zs+k+6WoVctvfW0=";
-                "risc0-cycle-utils-0.3.0" = "sha256-tl6TvAUghcJvlnbD1iYH4mHjgSEtNKsAYN9ZZP69pyc=";
+                "ibc-0.50.0" = "sha256-PakLJz3xIKXfW6iC4mB4KutOfAgn8jC/8t5epysZE5g=";
+                "ibc-proto-0.41.0" = "sha256-Q3JS+hAYivBZvtlgEM11qDp55d9clNztASNQE505oX8=";
+                "sov-celestia-client-0.1.0" = "sha256-P7Sqf9fhKaf8ZaccYiW83YImaPfefWLDF7HXSYcMQMs=";
+                "risc0-cycle-utils-0.3.0" = "sha256-5dA62v1eqfyZBny4s3YlC2Tty7Yfd/OAVGfTlLBgypk=";
+                "rockbound-1.0.0" = "sha256-x3yO3BcDdRPmz/p7qnLj+SKgi3meSniTraklWvzULco=";
             };
         };
 

--- a/rollup_config.toml
+++ b/rollup_config.toml
@@ -8,7 +8,7 @@ path = "../../rollup-starter-data"
 # We define the rollup's genesis to occur at block number `start_height`. The rollup will ignore
 # any blocks before this height
 [runner]
-start_height = 1
+genesis_height = 0
 da_polling_interval_ms = 1000
 
 [runner.rpc_config]

--- a/sov-rollup-starter.sh
+++ b/sov-rollup-starter.sh
@@ -6,35 +6,52 @@ if [ $? -ne 0 ]; then
     echo "Expected exit code 0, got $?"
     exit 1
 fi
+
 echo 'Running: '\''make clean-db'\'''
 make clean-db
 if [ $? -ne 0 ]; then
     echo "Expected exit code 0, got $?"
     exit 1
 fi
+
 echo 'Running: '\''cargo run --bin node'\'''
-cargo run --bin node &
-sleep 20
+output=$(mktemp)
+cargo run --bin node &> $output &
+background_process_pid=$!
+echo "Waiting for process with PID: $background_process_pid"
+until grep -q -i RPC $output
+do       
+  if ! ps $background_process_pid > /dev/null 
+  then
+    echo "The background process died" >&2
+    exit 1
+  fi
+  echo -n "."
+  sleep 5
+done
+
 echo 'Running: '\''make test-create-token'\'''
 make test-create-token
 if [ $? -ne 0 ]; then
     echo "Expected exit code 0, got $?"
     exit 1
 fi
+
 echo 'Running: '\''make wait-ten-seconds'\'''
 make wait-ten-seconds
 if [ $? -ne 0 ]; then
     echo "Expected exit code 0, got $?"
     exit 1
 fi
+
 echo 'Running: '\''make test-bank-supply-of'\'''
 make test-bank-supply-of
 if [ $? -ne 0 ]; then
     echo "Expected exit code 0, got $?"
     exit 1
 fi
-echo 'Running: '\''curl -X POST -H "Content-Type: application/json" -d '\''{"jsonrpc":"2.0","method":"bank_supplyOf","params":{"token_address":"sov1zdwj8thgev2u3yyrrlekmvtsz4av4tp3m7dm5mx5peejnesga27svq9m72"},"id":1}'\'' http://127.0.0.1:12345'\'''
 
+echo 'Running: '\''curl -X POST -H "Content-Type: application/json" -d '\''{"jsonrpc":"2.0","method":"bank_supplyOf","params":{"token_address":"sov1zdwj8thgev2u3yyrrlekmvtsz4av4tp3m7dm5mx5peejnesga27svq9m72"},"id":1}'\'' http://127.0.0.1:12345'\'''
 output=$(curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"bank_supplyOf","params":{"token_address":"sov1zdwj8thgev2u3yyrrlekmvtsz4av4tp3m7dm5mx5peejnesga27svq9m72"},"id":1}' http://127.0.0.1:12345)
 expected='{"jsonrpc":"2.0","result":{"amount":1000},"id":1}
 '
@@ -50,4 +67,5 @@ if [ $? -ne 0 ]; then
     echo "Expected exit code 0, got $?"
     exit 1
 fi
+
 echo "All tests passed!"; exit 0

--- a/test-data/genesis/celestia/chain_state.json
+++ b/test-data/genesis/celestia/chain_state.json
@@ -1,7 +1,16 @@
 {
-  "initial_slot_height": 0,
   "current_time": {
     "secs": 0,
     "nanos": 0
-  }
+  },
+  "gas_price_blocks_depth": 10,
+  "gas_price_maximum_elasticity": 5,
+  "initial_gas_price": [
+    0,
+    0
+  ],
+  "minimum_gas_price": [
+    0,
+    0
+  ]
 }

--- a/test-data/genesis/mock/chain_state.json
+++ b/test-data/genesis/mock/chain_state.json
@@ -1,5 +1,4 @@
 {
-  "initial_slot_height": 0,
   "current_time": {
     "secs": 0,
     "nanos": 0


### PR DESCRIPTION
## Description

This PR integrates changes in `sov-rollup-starter-wip` up to revision: [a3ff620](https://github.com/Sovereign-Labs/sov-rollup-starter-wip/commit/a3ff620606fabcc5ff7c7aa8b2050eaa1ec6eca6)