### PR TITLE
feat: integrate `sov-consensus-state-tracker` module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ docker/credentials/*
 !docker/credentials/bridge-0.key
 .keys
 result
+.vscode

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2147,7 +2147,8 @@ dependencies = [
 [[package]]
 name = "ibc"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8af2325614ae3274b2e70834bea56c1fa2758d802d364d89992b0fe820847fca"
 dependencies = [
  "ibc-apps",
  "ibc-clients",
@@ -2160,7 +2161,8 @@ dependencies = [
 [[package]]
 name = "ibc-app-nft-transfer"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "640bf8485d3b25ba08632438af56f334290387c13db9441ad5389936c1d8218e"
 dependencies = [
  "ibc-app-nft-transfer-types",
  "ibc-core",
@@ -2170,7 +2172,8 @@ dependencies = [
 [[package]]
 name = "ibc-app-nft-transfer-types"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4051c417a011a459080a58066a98f2c0b488171a8bf913af6a53bd34277f1b0b"
 dependencies = [
  "base64 0.21.7",
  "borsh",
@@ -2190,7 +2193,8 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63113a979118ad1474833bc4f01ad4fe87b17dcdd2f1376a67a2ac59d8c11434"
 dependencies = [
  "ibc-app-transfer-types",
  "ibc-core",
@@ -2200,7 +2204,8 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer-types"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1ff799a080f5c84316eb0b99f25fbc8b1790ab8c71c0ac465f88e4958e5a949"
 dependencies = [
  "borsh",
  "derive_more",
@@ -2216,7 +2221,8 @@ dependencies = [
 [[package]]
 name = "ibc-apps"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5325b71c21ea45f8a7f8df412e72a01b50f230b08b4120d6a233aeb4bf7b4a54"
 dependencies = [
  "ibc-app-nft-transfer",
  "ibc-app-transfer",
@@ -2225,7 +2231,8 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afa7a3fc87f5bf15c521ef2d63120173b074874df99198302b32d36fc5874614"
 dependencies = [
  "derive_more",
  "ibc-client-tendermint-types",
@@ -2242,7 +2249,8 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint-types"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e24507c8a710df38924981bd087fc52808f12eb5e6fb1e15b49180979a162fe5"
 dependencies = [
  "displaydoc",
  "ibc-core-client-types",
@@ -2259,7 +2267,8 @@ dependencies = [
 [[package]]
 name = "ibc-client-wasm-types"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5beac8a4f0affd642b47d21ac1dfc0d3c5fdccd032789ee40d882d46c1b677e3"
 dependencies = [
  "base64 0.21.7",
  "displaydoc",
@@ -2273,7 +2282,8 @@ dependencies = [
 [[package]]
 name = "ibc-clients"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cf6dce5f55eac4930a6e00808cd91d9eccffcb8b5d7c4717b57e9a11217be90"
 dependencies = [
  "ibc-client-tendermint",
  "ibc-client-wasm-types",
@@ -2282,7 +2292,8 @@ dependencies = [
 [[package]]
 name = "ibc-core"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecb68e9669c9946dec7453684b5ab05f9c307d908ebe174178bb63a839187f61"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -2298,7 +2309,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee95045592a67c58d3efd045c17a0923ce956f43c344d9673ff5de4d359b5f6c"
 dependencies = [
  "ibc-core-channel-types",
  "ibc-core-client",
@@ -2313,7 +2325,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel-types"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804776a40c68a3624b200a51ff9f9506e74d4eaf4dce482b07e68e7b12e6be7b"
 dependencies = [
  "borsh",
  "derive_more",
@@ -2336,7 +2349,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-client"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "015b28dbb91d6ec2bb82eb57bb34f65cf56e1111e61b82181ae6fb794aceac06"
 dependencies = [
  "ibc-core-client-context",
  "ibc-core-client-types",
@@ -2349,7 +2363,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-context"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9413a8d97d2c4c5dd0d1b673a09e43c80aabb209355e60681865f608bac0756"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -2365,7 +2380,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-types"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a053bd037d7a0d6d42c92321e4eafbc3a7dba2730a9172cb082ddca0215781a"
 dependencies = [
  "borsh",
  "derive_more",
@@ -2385,7 +2401,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-commitment-types"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4202b39be2ef46a110fbe6c258df8721bc5377878a74b9025deafec2d3495e2"
 dependencies = [
  "borsh",
  "derive_more",
@@ -2403,7 +2420,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-connection"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712bd6ca50a57b98dc514182f8046bb0456311c32950d149d0cc72a1aa07d012"
 dependencies = [
  "ibc-core-client",
  "ibc-core-connection-types",
@@ -2415,7 +2433,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-connection-types"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b86c2819e77deb658886b31cb50629ddca97a688a19cb962336a847305922c43"
 dependencies = [
  "borsh",
  "derive_more",
@@ -2436,7 +2455,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bf6cfdfacf8664f178a20269bb4f47252ab1c9a57b2530b2602e8b0b4e29c66"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -2451,7 +2471,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler-types"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "032c96b6f1ad4ee17c301335f5d36f0207e837fc351b416fffab9010c63de061"
 dependencies = [
  "borsh",
  "derive_more",
@@ -2475,7 +2496,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-host"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce0b51ac76f9542530ac531366702f16c732b1ba911890a153f1769e99a7277b"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -2493,7 +2515,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-host-cosmos"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab6cb1c979d58e146910bca01978c9151cedd2b9eabad7125ae8e14a59695450"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -2516,7 +2539,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-host-types"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b11fac91a80985a15eb3e0847fc962c21379982b6e06968595a4d274b10202eb"
 dependencies = [
  "borsh",
  "derive_more",
@@ -2531,7 +2555,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-router"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb4dc0d4b15127ebf3a31841830b57cbae7f3de1823d2e3f81b402fea4f9054e"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -2545,7 +2570,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-router-types"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b60996d3dbd3d40a2b01046b4f3edb8e332f8a72c6ab98ad046262ab9a35bbdb"
 dependencies = [
  "borsh",
  "derive_more",
@@ -2563,8 +2589,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-derive"
-version = "0.6.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f5010acf3b7fec09c24d05b946424a9f7884f9647ed837c1a1676d3eabac154"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2574,7 +2601,8 @@ dependencies = [
 [[package]]
 name = "ibc-primitives"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02bc4f3159464458522624bc2177f4fda02070d56042e652f886a6b738223bd"
 dependencies = [
  "borsh",
  "derive_more",
@@ -2614,7 +2642,8 @@ dependencies = [
 [[package]]
 name = "ibc-query"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f9f34977f9906193439aebe9ba423d0a4db8cba09e4908aefa095c844b773a5"
 dependencies = [
  "displaydoc",
  "ibc",
@@ -4976,7 +5005,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-client"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=5a8a685#5a8a685e136f91006f0689c257594f00b11f95cd"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=4c9bf15#4c9bf15730c2e8587df8a4aa26534fa8b73e7f7b"
 dependencies = [
  "derive_more",
  "ibc-client-tendermint",
@@ -4993,7 +5022,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-client-types"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=5a8a685#5a8a685e136f91006f0689c257594f00b11f95cd"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=4c9bf15#4c9bf15730c2e8587df8a4aa26534fa8b73e7f7b"
 dependencies = [
  "base64 0.21.7",
  "bytes",
@@ -5046,7 +5075,7 @@ dependencies = [
 [[package]]
 name = "sov-consensus-state-tracker"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=5a8a685#5a8a685e136f91006f0689c257594f00b11f95cd"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=4c9bf15#4c9bf15730c2e8587df8a4aa26534fa8b73e7f7b"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -5088,7 +5117,7 @@ dependencies = [
 [[package]]
 name = "sov-ibc"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=5a8a685#5a8a685e136f91006f0689c257594f00b11f95cd"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=4c9bf15#4c9bf15730c2e8587df8a4aa26534fa8b73e7f7b"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5118,7 +5147,7 @@ dependencies = [
 [[package]]
 name = "sov-ibc-proto"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=5a8a685#5a8a685e136f91006f0689c257594f00b11f95cd"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=4c9bf15#4c9bf15730c2e8587df8a4aa26534fa8b73e7f7b"
 dependencies = [
  "ibc-proto",
  "informalsystems-pbjson",
@@ -5130,7 +5159,7 @@ dependencies = [
 [[package]]
 name = "sov-ibc-transfer"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=5a8a685#5a8a685e136f91006f0689c257594f00b11f95cd"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=4c9bf15#4c9bf15730c2e8587df8a4aa26534fa8b73e7f7b"
 dependencies = [
  "anyhow",
  "base64 0.21.7",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3401,7 +3401,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b"
 dependencies = [
- "proc-macro-crate 3.1.0",
+ "proc-macro-crate 2.0.0",
  "proc-macro2",
  "quote",
  "syn 2.0.53",
@@ -3671,15 +3671,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e8366a6159044a37876a2b9817124296703c586a5c92e2c53751fa06d8d43e8"
 dependencies = [
  "toml_edit 0.20.7",
-]
-
-[[package]]
-name = "proc-macro-crate"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
-dependencies = [
- "toml_edit 0.21.1",
 ]
 
 [[package]]
@@ -4957,6 +4948,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
+source = "git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=cf048cd59#cf048cd59789209bb9c37effddd20efe19375bca"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5049,6 +5041,30 @@ dependencies = [
  "sov-bank",
  "sov-modules-api",
  "sov-rollup-interface",
+]
+
+[[package]]
+name = "sov-consensus-state-tracker"
+version = "0.1.0"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=5a8a685#5a8a685e136f91006f0689c257594f00b11f95cd"
+dependencies = [
+ "anyhow",
+ "base64 0.21.7",
+ "borsh",
+ "ibc-app-transfer",
+ "ibc-core",
+ "prost",
+ "serde",
+ "sov-celestia-adapter",
+ "sov-celestia-client",
+ "sov-ibc",
+ "sov-mock-da 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=cf048cd59)",
+ "sov-modules-api",
+ "sov-modules-core",
+ "sov-rollup-interface",
+ "tendermint 0.34.1",
+ "thiserror",
+ "uint",
 ]
 
 [[package]]
@@ -5159,6 +5175,24 @@ dependencies = [
 [[package]]
 name = "sov-mock-da"
 version = "0.3.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "borsh",
+ "bytes",
+ "futures",
+ "hex",
+ "serde",
+ "sha2 0.10.8",
+ "sov-rollup-interface",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "sov-mock-da"
+version = "0.3.0"
+source = "git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=cf048cd59#cf048cd59789209bb9c37effddd20efe19375bca"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5361,11 +5395,10 @@ dependencies = [
  "serde_json",
  "sov-accounts",
  "sov-bank",
- "sov-celestia-adapter",
  "sov-cli",
+ "sov-consensus-state-tracker",
  "sov-db",
  "sov-ledger-rpc",
- "sov-mock-da",
  "sov-mock-zkvm",
  "sov-modules-api",
  "sov-modules-rollup-blueprint",
@@ -5486,7 +5519,7 @@ dependencies = [
  "sov-attester-incentives",
  "sov-bank",
  "sov-chain-state",
- "sov-mock-da",
+ "sov-mock-da 0.3.0",
  "sov-mock-zkvm",
  "sov-modules-api",
  "sov-modules-stf-blueprint",
@@ -5557,7 +5590,6 @@ dependencies = [
  "sov-bank",
  "sov-ibc",
  "sov-ibc-transfer",
- "sov-mock-da",
  "sov-modules-api",
  "sov-modules-stf-blueprint",
  "sov-rollup-interface",
@@ -6015,17 +6047,6 @@ name = "toml_edit"
 version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
-dependencies = [
- "indexmap 2.2.5",
- "toml_datetime",
- "winnow 0.5.40",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
  "indexmap 2.2.5",
  "toml_datetime",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4977,7 +4977,6 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=cf048cd59#cf048cd59789209bb9c37effddd20efe19375bca"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5087,7 +5086,7 @@ dependencies = [
  "sov-celestia-adapter",
  "sov-celestia-client",
  "sov-ibc",
- "sov-mock-da 0.3.0 (git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=cf048cd59)",
+ "sov-mock-da",
  "sov-modules-api",
  "sov-modules-core",
  "sov-rollup-interface",
@@ -5204,24 +5203,6 @@ dependencies = [
 [[package]]
 name = "sov-mock-da"
 version = "0.3.0"
-dependencies = [
- "anyhow",
- "async-trait",
- "borsh",
- "bytes",
- "futures",
- "hex",
- "serde",
- "sha2 0.10.8",
- "sov-rollup-interface",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "sov-mock-da"
-version = "0.3.0"
-source = "git+ssh://git@github.com/informalsystems/sovereign-sdk-wip.git?rev=cf048cd59#cf048cd59789209bb9c37effddd20efe19375bca"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5548,7 +5529,7 @@ dependencies = [
  "sov-attester-incentives",
  "sov-bank",
  "sov-chain-state",
- "sov-mock-da 0.3.0",
+ "sov-mock-da",
  "sov-mock-zkvm",
  "sov-modules-api",
  "sov-modules-stf-blueprint",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5004,7 +5004,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-client"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=4c9bf15#4c9bf15730c2e8587df8a4aa26534fa8b73e7f7b"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=97aacfb#97aacfb514bfb05638d4c042eb20ad9b38a73624"
 dependencies = [
  "derive_more",
  "ibc-client-tendermint",
@@ -5021,7 +5021,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-client-types"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=4c9bf15#4c9bf15730c2e8587df8a4aa26534fa8b73e7f7b"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=97aacfb#97aacfb514bfb05638d4c042eb20ad9b38a73624"
 dependencies = [
  "base64 0.21.7",
  "bytes",
@@ -5074,7 +5074,7 @@ dependencies = [
 [[package]]
 name = "sov-consensus-state-tracker"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=4c9bf15#4c9bf15730c2e8587df8a4aa26534fa8b73e7f7b"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=97aacfb#97aacfb514bfb05638d4c042eb20ad9b38a73624"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -5116,7 +5116,7 @@ dependencies = [
 [[package]]
 name = "sov-ibc"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=4c9bf15#4c9bf15730c2e8587df8a4aa26534fa8b73e7f7b"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=97aacfb#97aacfb514bfb05638d4c042eb20ad9b38a73624"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5146,7 +5146,7 @@ dependencies = [
 [[package]]
 name = "sov-ibc-proto"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=4c9bf15#4c9bf15730c2e8587df8a4aa26534fa8b73e7f7b"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=97aacfb#97aacfb514bfb05638d4c042eb20ad9b38a73624"
 dependencies = [
  "ibc-proto",
  "informalsystems-pbjson",
@@ -5158,7 +5158,7 @@ dependencies = [
 [[package]]
 name = "sov-ibc-transfer"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=4c9bf15#4c9bf15730c2e8587df8a4aa26534fa8b73e7f7b"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=97aacfb#97aacfb514bfb05638d4c042eb20ad9b38a73624"
 dependencies = [
  "anyhow",
  "base64 0.21.7",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,9 +66,11 @@ risc0-build = "0.20"
 crypto-bigint = { git = "https://github.com/risc0/RustCrypto-crypto-bigint", tag = "v0.5.2-risc0"}
 
 [patch.'ssh://git@github.com/informalsystems/sovereign-sdk-wip.git']
-sov-modules-api      = { path = "./vendor/sovereign-sdk/module-system/sov-modules-api" }
-sov-state            = { path = "./vendor/sovereign-sdk/module-system/sov-state" }
-sov-bank             = { path = "./vendor/sovereign-sdk/module-system/module-implementations/sov-bank" }
-sov-chain-state      = { path = "./vendor/sovereign-sdk/module-system/module-implementations/sov-chain-state" }
-sov-rollup-interface = { path = "./vendor/sovereign-sdk/rollup-interface" }
-sov-modules-core     = { path = "./vendor/sovereign-sdk/module-system/sov-modules-core" }
+sov-modules-api         = { path = "./vendor/sovereign-sdk/module-system/sov-modules-api" }
+sov-state               = { path = "./vendor/sovereign-sdk/module-system/sov-state" }
+sov-bank                = { path = "./vendor/sovereign-sdk/module-system/module-implementations/sov-bank" }
+sov-chain-state         = { path = "./vendor/sovereign-sdk/module-system/module-implementations/sov-chain-state" }
+sov-rollup-interface    = { path = "./vendor/sovereign-sdk/rollup-interface" }
+sov-modules-core        = { path = "./vendor/sovereign-sdk/module-system/sov-modules-core" }
+sov-mock-da             = { path = "./vendor/sovereign-sdk/adapters/mock-da" }
+sov-celestia-adapter    = { path = "./vendor/sovereign-sdk/adapters/celestia" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,9 +38,9 @@ sov-mock-zkvm                   = { path = "./vendor/sovereign-sdk/adapters/mock
 sov-cli                         = { path = "./vendor/sovereign-sdk/module-system/sov-cli" }
 sov-prover-storage-manager      = { path = "./vendor/sovereign-sdk/full-node/sov-prover-storage-manager" }
 
-sov-ibc                         = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "5a8a685" }
-sov-ibc-transfer                = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "5a8a685" }
-sov-consensus-state-tracker     = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "5a8a685" }
+sov-ibc                         = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "4c9bf15" }
+sov-ibc-transfer                = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "4c9bf15" }
+sov-consensus-state-tracker     = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "4c9bf15" }
 
 stf-starter = { path = "./crates/stf" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,9 +38,9 @@ sov-mock-zkvm                   = { path = "./vendor/sovereign-sdk/adapters/mock
 sov-cli                         = { path = "./vendor/sovereign-sdk/module-system/sov-cli" }
 sov-prover-storage-manager      = { path = "./vendor/sovereign-sdk/full-node/sov-prover-storage-manager" }
 
-sov-ibc                         = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "4c9bf15" }
-sov-ibc-transfer                = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "4c9bf15" }
-sov-consensus-state-tracker     = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "4c9bf15" }
+sov-ibc                         = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "97aacfb" }
+sov-ibc-transfer                = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "97aacfb" }
+sov-consensus-state-tracker     = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "97aacfb" }
 
 stf-starter = { path = "./crates/stf" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,12 +36,11 @@ sov-rollup-interface            = { path = "./vendor/sovereign-sdk/rollup-interf
 sov-risc0-adapter               = { path = "./vendor/sovereign-sdk/adapters/risc0" }
 sov-mock-zkvm                   = { path = "./vendor/sovereign-sdk/adapters/mock-zkvm" }
 sov-cli                         = { path = "./vendor/sovereign-sdk/module-system/sov-cli" }
-sov-mock-da                     = { path = "./vendor/sovereign-sdk/adapters/mock-da" }
-sov-celestia-adapter            = { path = "./vendor/sovereign-sdk/adapters/celestia" }
 sov-prover-storage-manager      = { path = "./vendor/sovereign-sdk/full-node/sov-prover-storage-manager" }
 
 sov-ibc                         = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "5a8a685" }
 sov-ibc-transfer                = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "5a8a685" }
+sov-consensus-state-tracker     = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "5a8a685" }
 
 stf-starter = { path = "./crates/stf" }
 
@@ -72,3 +71,4 @@ sov-state            = { path = "./vendor/sovereign-sdk/module-system/sov-state"
 sov-bank             = { path = "./vendor/sovereign-sdk/module-system/module-implementations/sov-bank" }
 sov-chain-state      = { path = "./vendor/sovereign-sdk/module-system/module-implementations/sov-chain-state" }
 sov-rollup-interface = { path = "./vendor/sovereign-sdk/rollup-interface" }
+sov-modules-core     = { path = "./vendor/sovereign-sdk/module-system/sov-modules-core" }

--- a/crates/provers/risc0/guest-celestia/Cargo.lock
+++ b/crates/provers/risc0/guest-celestia/Cargo.lock
@@ -2569,7 +2569,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-client"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=4c9bf15#4c9bf15730c2e8587df8a4aa26534fa8b73e7f7b"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=97aacfb#97aacfb514bfb05638d4c042eb20ad9b38a73624"
 dependencies = [
  "derive_more",
  "ibc-client-tendermint",
@@ -2586,7 +2586,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-client-types"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=4c9bf15#4c9bf15730c2e8587df8a4aa26534fa8b73e7f7b"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=97aacfb#97aacfb514bfb05638d4c042eb20ad9b38a73624"
 dependencies = [
  "base64",
  "bytes",
@@ -2637,7 +2637,7 @@ dependencies = [
 [[package]]
 name = "sov-ibc"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=4c9bf15#4c9bf15730c2e8587df8a4aa26534fa8b73e7f7b"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=97aacfb#97aacfb514bfb05638d4c042eb20ad9b38a73624"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2664,7 +2664,7 @@ dependencies = [
 [[package]]
 name = "sov-ibc-proto"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=4c9bf15#4c9bf15730c2e8587df8a4aa26534fa8b73e7f7b"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=97aacfb#97aacfb514bfb05638d4c042eb20ad9b38a73624"
 dependencies = [
  "ibc-proto",
  "informalsystems-pbjson",
@@ -2676,7 +2676,7 @@ dependencies = [
 [[package]]
 name = "sov-ibc-transfer"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=4c9bf15#4c9bf15730c2e8587df8a4aa26534fa8b73e7f7b"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=97aacfb#97aacfb514bfb05638d4c042eb20ad9b38a73624"
 dependencies = [
  "anyhow",
  "base64",

--- a/crates/provers/risc0/guest-celestia/Cargo.lock
+++ b/crates/provers/risc0/guest-celestia/Cargo.lock
@@ -1093,7 +1093,8 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63113a979118ad1474833bc4f01ad4fe87b17dcdd2f1376a67a2ac59d8c11434"
 dependencies = [
  "ibc-app-transfer-types",
  "ibc-core",
@@ -1103,7 +1104,8 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer-types"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1ff799a080f5c84316eb0b99f25fbc8b1790ab8c71c0ac465f88e4958e5a949"
 dependencies = [
  "borsh",
  "derive_more",
@@ -1119,7 +1121,8 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afa7a3fc87f5bf15c521ef2d63120173b074874df99198302b32d36fc5874614"
 dependencies = [
  "derive_more",
  "ibc-client-tendermint-types",
@@ -1136,7 +1139,8 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint-types"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e24507c8a710df38924981bd087fc52808f12eb5e6fb1e15b49180979a162fe5"
 dependencies = [
  "displaydoc",
  "ibc-core-client-types",
@@ -1153,7 +1157,8 @@ dependencies = [
 [[package]]
 name = "ibc-core"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecb68e9669c9946dec7453684b5ab05f9c307d908ebe174178bb63a839187f61"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -1169,7 +1174,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee95045592a67c58d3efd045c17a0923ce956f43c344d9673ff5de4d359b5f6c"
 dependencies = [
  "ibc-core-channel-types",
  "ibc-core-client",
@@ -1184,7 +1190,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel-types"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804776a40c68a3624b200a51ff9f9506e74d4eaf4dce482b07e68e7b12e6be7b"
 dependencies = [
  "borsh",
  "derive_more",
@@ -1205,7 +1212,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-client"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "015b28dbb91d6ec2bb82eb57bb34f65cf56e1111e61b82181ae6fb794aceac06"
 dependencies = [
  "ibc-core-client-context",
  "ibc-core-client-types",
@@ -1218,7 +1226,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-context"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9413a8d97d2c4c5dd0d1b673a09e43c80aabb209355e60681865f608bac0756"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1234,7 +1243,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-types"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a053bd037d7a0d6d42c92321e4eafbc3a7dba2730a9172cb082ddca0215781a"
 dependencies = [
  "borsh",
  "derive_more",
@@ -1252,7 +1262,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-commitment-types"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4202b39be2ef46a110fbe6c258df8721bc5377878a74b9025deafec2d3495e2"
 dependencies = [
  "borsh",
  "derive_more",
@@ -1268,7 +1279,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-connection"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712bd6ca50a57b98dc514182f8046bb0456311c32950d149d0cc72a1aa07d012"
 dependencies = [
  "ibc-core-client",
  "ibc-core-connection-types",
@@ -1280,7 +1292,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-connection-types"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b86c2819e77deb658886b31cb50629ddca97a688a19cb962336a847305922c43"
 dependencies = [
  "borsh",
  "derive_more",
@@ -1299,7 +1312,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bf6cfdfacf8664f178a20269bb4f47252ab1c9a57b2530b2602e8b0b4e29c66"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -1314,7 +1328,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler-types"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "032c96b6f1ad4ee17c301335f5d36f0207e837fc351b416fffab9010c63de061"
 dependencies = [
  "borsh",
  "derive_more",
@@ -1336,7 +1351,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-host"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce0b51ac76f9542530ac531366702f16c732b1ba911890a153f1769e99a7277b"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1354,7 +1370,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-host-types"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b11fac91a80985a15eb3e0847fc962c21379982b6e06968595a4d274b10202eb"
 dependencies = [
  "borsh",
  "derive_more",
@@ -1367,7 +1384,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-router"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb4dc0d4b15127ebf3a31841830b57cbae7f3de1823d2e3f81b402fea4f9054e"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1381,7 +1399,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-router-types"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b60996d3dbd3d40a2b01046b4f3edb8e332f8a72c6ab98ad046262ab9a35bbdb"
 dependencies = [
  "borsh",
  "derive_more",
@@ -1397,8 +1416,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-derive"
-version = "0.6.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f5010acf3b7fec09c24d05b946424a9f7884f9647ed837c1a1676d3eabac154"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1408,7 +1428,8 @@ dependencies = [
 [[package]]
 name = "ibc-primitives"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02bc4f3159464458522624bc2177f4fda02070d56042e652f886a6b738223bd"
 dependencies = [
  "borsh",
  "derive_more",
@@ -2548,7 +2569,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-client"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=5a8a685#5a8a685e136f91006f0689c257594f00b11f95cd"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=4c9bf15#4c9bf15730c2e8587df8a4aa26534fa8b73e7f7b"
 dependencies = [
  "derive_more",
  "ibc-client-tendermint",
@@ -2565,7 +2586,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-client-types"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=5a8a685#5a8a685e136f91006f0689c257594f00b11f95cd"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=4c9bf15#4c9bf15730c2e8587df8a4aa26534fa8b73e7f7b"
 dependencies = [
  "base64",
  "bytes",
@@ -2616,7 +2637,7 @@ dependencies = [
 [[package]]
 name = "sov-ibc"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=5a8a685#5a8a685e136f91006f0689c257594f00b11f95cd"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=4c9bf15#4c9bf15730c2e8587df8a4aa26534fa8b73e7f7b"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2643,7 +2664,7 @@ dependencies = [
 [[package]]
 name = "sov-ibc-proto"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=5a8a685#5a8a685e136f91006f0689c257594f00b11f95cd"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=4c9bf15#4c9bf15730c2e8587df8a4aa26534fa8b73e7f7b"
 dependencies = [
  "ibc-proto",
  "informalsystems-pbjson",
@@ -2655,7 +2676,7 @@ dependencies = [
 [[package]]
 name = "sov-ibc-transfer"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=5a8a685#5a8a685e136f91006f0689c257594f00b11f95cd"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=4c9bf15#4c9bf15730c2e8587df8a4aa26534fa8b73e7f7b"
 dependencies = [
  "anyhow",
  "base64",

--- a/crates/provers/risc0/guest-celestia/Cargo.lock
+++ b/crates/provers/risc0/guest-celestia/Cargo.lock
@@ -2677,21 +2677,6 @@ name = "sov-metrics"
 version = "0.3.0"
 
 [[package]]
-name = "sov-mock-da"
-version = "0.3.0"
-dependencies = [
- "anyhow",
- "async-trait",
- "borsh",
- "bytes",
- "hex",
- "serde",
- "sha2 0.10.8",
- "sov-rollup-interface",
- "tracing",
-]
-
-[[package]]
 name = "sov-modules-api"
 version = "0.3.0"
 dependencies = [
@@ -2873,7 +2858,6 @@ dependencies = [
  "sov-bank",
  "sov-ibc",
  "sov-ibc-transfer",
- "sov-mock-da",
  "sov-modules-api",
  "sov-modules-stf-blueprint",
  "sov-rollup-interface",

--- a/crates/provers/risc0/guest-mock/Cargo.lock
+++ b/crates/provers/risc0/guest-mock/Cargo.lock
@@ -2021,7 +2021,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-client"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=4c9bf15#4c9bf15730c2e8587df8a4aa26534fa8b73e7f7b"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=97aacfb#97aacfb514bfb05638d4c042eb20ad9b38a73624"
 dependencies = [
  "derive_more",
  "ibc-client-tendermint",
@@ -2038,7 +2038,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-client-types"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=4c9bf15#4c9bf15730c2e8587df8a4aa26534fa8b73e7f7b"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=97aacfb#97aacfb514bfb05638d4c042eb20ad9b38a73624"
 dependencies = [
  "base64",
  "bytes",
@@ -2071,7 +2071,7 @@ dependencies = [
 [[package]]
 name = "sov-ibc"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=4c9bf15#4c9bf15730c2e8587df8a4aa26534fa8b73e7f7b"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=97aacfb#97aacfb514bfb05638d4c042eb20ad9b38a73624"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2098,7 +2098,7 @@ dependencies = [
 [[package]]
 name = "sov-ibc-proto"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=4c9bf15#4c9bf15730c2e8587df8a4aa26534fa8b73e7f7b"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=97aacfb#97aacfb514bfb05638d4c042eb20ad9b38a73624"
 dependencies = [
  "ibc-proto",
  "informalsystems-pbjson",
@@ -2110,7 +2110,7 @@ dependencies = [
 [[package]]
 name = "sov-ibc-transfer"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=4c9bf15#4c9bf15730c2e8587df8a4aa26534fa8b73e7f7b"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=97aacfb#97aacfb514bfb05638d4c042eb20ad9b38a73624"
 dependencies = [
  "anyhow",
  "base64",

--- a/crates/provers/risc0/guest-mock/Cargo.lock
+++ b/crates/provers/risc0/guest-mock/Cargo.lock
@@ -2307,7 +2307,6 @@ dependencies = [
  "sov-bank",
  "sov-ibc",
  "sov-ibc-transfer",
- "sov-mock-da",
  "sov-modules-api",
  "sov-modules-stf-blueprint",
  "sov-rollup-interface",

--- a/crates/provers/risc0/guest-mock/Cargo.lock
+++ b/crates/provers/risc0/guest-mock/Cargo.lock
@@ -834,7 +834,8 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63113a979118ad1474833bc4f01ad4fe87b17dcdd2f1376a67a2ac59d8c11434"
 dependencies = [
  "ibc-app-transfer-types",
  "ibc-core",
@@ -844,7 +845,8 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer-types"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1ff799a080f5c84316eb0b99f25fbc8b1790ab8c71c0ac465f88e4958e5a949"
 dependencies = [
  "borsh",
  "derive_more",
@@ -860,7 +862,8 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afa7a3fc87f5bf15c521ef2d63120173b074874df99198302b32d36fc5874614"
 dependencies = [
  "derive_more",
  "ibc-client-tendermint-types",
@@ -877,7 +880,8 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint-types"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e24507c8a710df38924981bd087fc52808f12eb5e6fb1e15b49180979a162fe5"
 dependencies = [
  "displaydoc",
  "ibc-core-client-types",
@@ -894,7 +898,8 @@ dependencies = [
 [[package]]
 name = "ibc-core"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecb68e9669c9946dec7453684b5ab05f9c307d908ebe174178bb63a839187f61"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -910,7 +915,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee95045592a67c58d3efd045c17a0923ce956f43c344d9673ff5de4d359b5f6c"
 dependencies = [
  "ibc-core-channel-types",
  "ibc-core-client",
@@ -925,7 +931,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel-types"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804776a40c68a3624b200a51ff9f9506e74d4eaf4dce482b07e68e7b12e6be7b"
 dependencies = [
  "borsh",
  "derive_more",
@@ -946,7 +953,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-client"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "015b28dbb91d6ec2bb82eb57bb34f65cf56e1111e61b82181ae6fb794aceac06"
 dependencies = [
  "ibc-core-client-context",
  "ibc-core-client-types",
@@ -959,7 +967,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-context"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9413a8d97d2c4c5dd0d1b673a09e43c80aabb209355e60681865f608bac0756"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -975,7 +984,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-types"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a053bd037d7a0d6d42c92321e4eafbc3a7dba2730a9172cb082ddca0215781a"
 dependencies = [
  "borsh",
  "derive_more",
@@ -993,7 +1003,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-commitment-types"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4202b39be2ef46a110fbe6c258df8721bc5377878a74b9025deafec2d3495e2"
 dependencies = [
  "borsh",
  "derive_more",
@@ -1009,7 +1020,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-connection"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712bd6ca50a57b98dc514182f8046bb0456311c32950d149d0cc72a1aa07d012"
 dependencies = [
  "ibc-core-client",
  "ibc-core-connection-types",
@@ -1021,7 +1033,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-connection-types"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b86c2819e77deb658886b31cb50629ddca97a688a19cb962336a847305922c43"
 dependencies = [
  "borsh",
  "derive_more",
@@ -1040,7 +1053,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bf6cfdfacf8664f178a20269bb4f47252ab1c9a57b2530b2602e8b0b4e29c66"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -1055,7 +1069,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler-types"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "032c96b6f1ad4ee17c301335f5d36f0207e837fc351b416fffab9010c63de061"
 dependencies = [
  "borsh",
  "derive_more",
@@ -1077,7 +1092,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-host"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce0b51ac76f9542530ac531366702f16c732b1ba911890a153f1769e99a7277b"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1095,7 +1111,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-host-types"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b11fac91a80985a15eb3e0847fc962c21379982b6e06968595a4d274b10202eb"
 dependencies = [
  "borsh",
  "derive_more",
@@ -1108,7 +1125,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-router"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb4dc0d4b15127ebf3a31841830b57cbae7f3de1823d2e3f81b402fea4f9054e"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1122,7 +1140,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-router-types"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b60996d3dbd3d40a2b01046b4f3edb8e332f8a72c6ab98ad046262ab9a35bbdb"
 dependencies = [
  "borsh",
  "derive_more",
@@ -1138,8 +1157,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-derive"
-version = "0.6.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f5010acf3b7fec09c24d05b946424a9f7884f9647ed837c1a1676d3eabac154"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1149,7 +1169,8 @@ dependencies = [
 [[package]]
 name = "ibc-primitives"
 version = "0.51.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=984f5cd#984f5cdb4110123b1227f09637f6e2e0f12669d2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02bc4f3159464458522624bc2177f4fda02070d56042e652f886a6b738223bd"
 dependencies = [
  "borsh",
  "derive_more",
@@ -2000,7 +2021,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-client"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=5a8a685#5a8a685e136f91006f0689c257594f00b11f95cd"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=4c9bf15#4c9bf15730c2e8587df8a4aa26534fa8b73e7f7b"
 dependencies = [
  "derive_more",
  "ibc-client-tendermint",
@@ -2017,7 +2038,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-client-types"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=5a8a685#5a8a685e136f91006f0689c257594f00b11f95cd"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=4c9bf15#4c9bf15730c2e8587df8a4aa26534fa8b73e7f7b"
 dependencies = [
  "base64",
  "bytes",
@@ -2050,7 +2071,7 @@ dependencies = [
 [[package]]
 name = "sov-ibc"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=5a8a685#5a8a685e136f91006f0689c257594f00b11f95cd"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=4c9bf15#4c9bf15730c2e8587df8a4aa26534fa8b73e7f7b"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2077,7 +2098,7 @@ dependencies = [
 [[package]]
 name = "sov-ibc-proto"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=5a8a685#5a8a685e136f91006f0689c257594f00b11f95cd"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=4c9bf15#4c9bf15730c2e8587df8a4aa26534fa8b73e7f7b"
 dependencies = [
  "ibc-proto",
  "informalsystems-pbjson",
@@ -2089,7 +2110,7 @@ dependencies = [
 [[package]]
 name = "sov-ibc-transfer"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=5a8a685#5a8a685e136f91006f0689c257594f00b11f95cd"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=4c9bf15#4c9bf15730c2e8587df8a4aa26534fa8b73e7f7b"
 dependencies = [
  "anyhow",
  "base64",

--- a/crates/provers/risc0/guest-mock/src/bin/mock_da.rs
+++ b/crates/provers/risc0/guest-mock/src/bin/mock_da.rs
@@ -7,9 +7,9 @@ use sov_modules_api::default_spec::ZkDefaultSpec;
 use sov_modules_stf_blueprint::kernels::basic::BasicKernel;
 use sov_modules_stf_blueprint::StfBlueprint;
 use sov_risc0_adapter::guest::Risc0Guest;
+use sov_risc0_adapter::Risc0Verifier;
 use sov_state::ZkStorage;
 use stf_starter::runtime::Runtime;
-use sov_risc0_adapter::Risc0Verifier;
 use stf_starter::StfVerifier;
 
 #[cfg(feature = "bench")]
@@ -36,7 +36,7 @@ pub fn main() {
     let guest = Risc0Guest::new();
     let storage = ZkStorage::new();
     #[cfg(feature = "bench")]
-        let start_cycles = risc0_zkvm_platform::syscall::sys_cycle_count();
+    let start_cycles = risc0_zkvm_platform::syscall::sys_cycle_count();
 
     let stf: StfBlueprint<ZkDefaultSpec<Risc0Verifier>, _, _, Runtime<_, _>, BasicKernel<_, _>> =
         StfBlueprint::new();

--- a/crates/rollup/Cargo.toml
+++ b/crates/rollup/Cargo.toml
@@ -27,8 +27,6 @@ sov-cli = { workspace = true}
 sov-db = { workspace = true }
 sov-sequencer = { workspace = true }
 sov-rollup-interface = { workspace = true }
-sov-mock-da = { workspace = true, features = ["native"], optional=true }
-sov-celestia-adapter = { workspace = true, features = ["native"], optional=true }
 
 anyhow = { workspace = true }
 async-trait = { workspace = true }
@@ -44,6 +42,7 @@ prometheus_exporter = { workspace = true }
 risc0-starter = { path = "../provers/risc0" }
 stf-starter = { path = "../stf", features = ["native"] }
 sov-risc0-adapter = { workspace = true, features = ["native"] }
+sov-consensus-state-tracker = { workspace = true, optional = true }
 
 # binary dependencies
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
@@ -56,8 +55,8 @@ sov-mock-zkvm = { workspace = true, features = ["native"] }
 
 [features]
 default = ["mock_da"] # set mock_da as the default feature
-mock_da = ["sov-mock-da"]
-celestia_da = ["sov-celestia-adapter"]
+mock_da = ["sov-consensus-state-tracker/mock-da"]
+celestia_da = ["sov-consensus-state-tracker/celestia-da"]
 test = ["mock_da"]
 
 [[bin]]

--- a/crates/rollup/src/bin/node.rs
+++ b/crates/rollup/src/bin/node.rs
@@ -3,9 +3,9 @@
 use anyhow::Context;
 use clap::Parser;
 #[cfg(feature = "celestia_da")]
-use sov_celestia_adapter::CelestiaConfig;
+use sov_consensus_state_tracker::CelestiaConfig;
 #[cfg(feature = "mock_da")]
-use sov_mock_da::MockDaConfig;
+use sov_consensus_state_tracker::MockDaConfig;
 use sov_modules_rollup_blueprint::{Rollup, RollupBlueprint};
 use sov_modules_stf_blueprint::kernels::basic::BasicKernelGenesisConfig;
 use sov_modules_stf_blueprint::kernels::basic::BasicKernelGenesisPaths;

--- a/crates/rollup/src/celestia_rollup.rs
+++ b/crates/rollup/src/celestia_rollup.rs
@@ -3,10 +3,10 @@
 
 use async_trait::async_trait;
 use sov_consensus_state_tracker::types::Namespace;
-use sov_consensus_state_tracker::verifier::address::CelestiaAddress;
 use sov_consensus_state_tracker::verifier::{CelestiaSpec, CelestiaVerifier, RollupParams};
 use sov_consensus_state_tracker::ConsensusStateTracker;
 use sov_consensus_state_tracker::{CelestiaConfig, CelestiaService};
+use sov_db::sequencer_db::SequencerDB;
 use sov_modules_api::default_spec::{DefaultSpec, ZkDefaultSpec};
 use sov_modules_api::Spec;
 use sov_modules_rollup_blueprint::RollupBlueprint;

--- a/crates/rollup/src/celestia_rollup.rs
+++ b/crates/rollup/src/celestia_rollup.rs
@@ -2,11 +2,11 @@
 //! StarterRollup provides a minimal self-contained rollup implementation
 
 use async_trait::async_trait;
-use sov_celestia_adapter::types::Namespace;
-use sov_celestia_adapter::verifier::address::CelestiaAddress;
-use sov_celestia_adapter::verifier::{CelestiaSpec, CelestiaVerifier, RollupParams};
-use sov_celestia_adapter::{CelestiaConfig, CelestiaService};
-use sov_db::sequencer_db::SequencerDB;
+use sov_consensus_state_tracker::types::Namespace;
+use sov_consensus_state_tracker::verifier::address::CelestiaAddress;
+use sov_consensus_state_tracker::verifier::{CelestiaSpec, CelestiaVerifier, RollupParams};
+use sov_consensus_state_tracker::ConsensusStateTracker;
+use sov_consensus_state_tracker::{CelestiaConfig, CelestiaService};
 use sov_modules_api::default_spec::{DefaultSpec, ZkDefaultSpec};
 use sov_modules_api::Spec;
 use sov_modules_rollup_blueprint::RollupBlueprint;
@@ -57,8 +57,13 @@ impl RollupBlueprint for CelestiaRollup {
 
     type NativeRuntime = Runtime<Self::NativeSpec, Self::DaSpec>;
 
-    type NativeKernel = BasicKernel<Self::NativeSpec, Self::DaSpec>;
-    type ZkKernel = BasicKernel<Self::ZkSpec, Self::DaSpec>;
+    type NativeKernel = ConsensusStateTracker<
+        BasicKernel<Self::NativeSpec, Self::DaSpec>,
+        Self::NativeSpec,
+        Self::DaSpec,
+    >;
+    type ZkKernel =
+        ConsensusStateTracker<BasicKernel<Self::ZkSpec, Self::DaSpec>, Self::ZkSpec, Self::DaSpec>;
 
     type ProverService = ParallelProverService<
         <<Self::NativeSpec as Spec>::Storage as Storage>::Root,

--- a/crates/rollup/src/celestia_rollup.rs
+++ b/crates/rollup/src/celestia_rollup.rs
@@ -23,8 +23,6 @@ use sov_state::{DefaultStorageSpec, ZkStorage};
 use sov_stf_runner::ParallelProverService;
 use sov_stf_runner::RollupConfig;
 use sov_stf_runner::RollupProverConfig;
-use std::str::FromStr;
-use std::sync::{Arc, RwLock};
 use stf_starter::Runtime;
 use tokio::sync::watch;
 

--- a/crates/rollup/src/mock_rollup.rs
+++ b/crates/rollup/src/mock_rollup.rs
@@ -2,9 +2,8 @@
 //! StarterRollup provides a minimal self-contained rollup implementation
 
 use async_trait::async_trait;
+use sov_consensus_state_tracker::{MockAddress, MockDaConfig, MockDaService, MockDaSpec};
 use sov_db::ledger_db::LedgerDB;
-use sov_db::sequencer_db::SequencerDB;
-use sov_mock_da::{MockDaConfig, MockDaService, MockDaSpec};
 use sov_modules_api::default_spec::{DefaultSpec, ZkDefaultSpec};
 use sov_modules_api::Spec;
 use sov_modules_rollup_blueprint::RollupBlueprint;

--- a/crates/rollup/src/mock_rollup.rs
+++ b/crates/rollup/src/mock_rollup.rs
@@ -2,8 +2,10 @@
 //! StarterRollup provides a minimal self-contained rollup implementation
 
 use async_trait::async_trait;
-use sov_consensus_state_tracker::{MockAddress, MockDaConfig, MockDaService, MockDaSpec};
+use sov_consensus_state_tracker::{MockDaConfig, MockDaService, MockDaSpec};
+
 use sov_db::ledger_db::LedgerDB;
+use sov_db::sequencer_db::SequencerDB;
 use sov_modules_api::default_spec::{DefaultSpec, ZkDefaultSpec};
 use sov_modules_api::Spec;
 use sov_modules_rollup_blueprint::RollupBlueprint;

--- a/crates/rollup/tests/bank/mod.rs
+++ b/crates/rollup/tests/bank/mod.rs
@@ -4,7 +4,7 @@ use super::test_helpers::start_rollup;
 use borsh::BorshSerialize;
 use jsonrpsee::core::client::{Subscription, SubscriptionClientT};
 use jsonrpsee::rpc_params;
-use sov_mock_da::{MockAddress, MockDaConfig, MockDaSpec};
+use sov_consensus_state_tracker::{MockAddress, MockDaConfig, MockDaSpec};
 use sov_modules_api::transaction::Transaction;
 use sov_modules_api::{CryptoSpec, PrivateKey, Spec};
 use sov_modules_stf_blueprint::kernels::basic::BasicKernelGenesisPaths;

--- a/crates/rollup/tests/test_helpers.rs
+++ b/crates/rollup/tests/test_helpers.rs
@@ -1,6 +1,6 @@
 use std::net::SocketAddr;
 
-use sov_mock_da::MockDaConfig;
+use sov_consensus_state_tracker::MockDaConfig;
 use sov_modules_rollup_blueprint::RollupBlueprint;
 use sov_modules_stf_blueprint::kernels::basic::BasicKernelGenesisConfig;
 use sov_modules_stf_blueprint::kernels::basic::BasicKernelGenesisPaths;

--- a/crates/stf/Cargo.toml
+++ b/crates/stf/Cargo.toml
@@ -16,7 +16,6 @@ sov-bank = { workspace = true }
 sov-ibc = { workspace = true, features = ["serde"] }
 sov-ibc-transfer = { workspace = true, features = ["serde"] }
 sov-sequencer-registry = { workspace = true }
-sov-mock-da = { workspace = true }
 sov-modules-stf-blueprint = { workspace = true }
 sov-stf-runner = { workspace = true }
 sov-sequencer = { workspace = true, optional = true }
@@ -40,7 +39,8 @@ native = [
     "sov-ibc/native",
     "sov-ibc-transfer/native",
     "sov-sequencer-registry/native",
-    "sov-mock-da/native",
+	"sov-rollup-interface/native",
+	"sov-state/native",
     "sov-modules-stf-blueprint/native",
     "sov-stf-runner/native",
     "jsonrpsee",
@@ -48,3 +48,4 @@ native = [
     "clap",
     "tokio"
 ]
+

--- a/crates/stf/src/lib.rs
+++ b/crates/stf/src/lib.rs
@@ -16,5 +16,3 @@ pub type StfVerifier<DA, Vm, ZkSpec, RT, K> = StateTransitionVerifier<
     DA,
     Vm,
 >;
-
-pub use sov_mock_da::MockDaSpec;

--- a/nix/rollup.nix
+++ b/nix/rollup.nix
@@ -51,7 +51,7 @@ let
                 "curve25519-dalek-4.1.0" = "sha256-H8YMea3AIcUn9NGRfataNjCTzCK4NAjo4ZhWuPfT6ts=";
                 "sha2-0.10.8" = "sha256-vuFQFlbDXEW+n9+Nx2VeWanggCSd6NZ+GVEDFS9qZ2M=";
                 "risc0-cycle-utils-0.3.0" = "sha256-5dA62v1eqfyZBny4s3YlC2Tty7Yfd/OAVGfTlLBgypk=";
-                "sov-celestia-client-0.1.0" = "sha256-Z3SvuWKPz+fPwHn1Nsj6cHUdrLzVOx+PkZS6D6558Sc=";
+                "sov-celestia-client-0.1.0" = "sha256-2z2KQY1Txo6SqneXxG3nR8x4smbR+Nqv5cTqG0P3TXE=";
             };
         };
 
@@ -94,7 +94,7 @@ let
                 "sha2-0.10.8" = "sha256-vuFQFlbDXEW+n9+Nx2VeWanggCSd6NZ+GVEDFS9qZ2M=";
                 "tendermint-0.32.0" = "sha256-FtY7a+hBvQryATrs3mykCWFRe8ABTT6cuf5oh9IBElQ=";
                 "risc0-cycle-utils-0.3.0" = "sha256-5dA62v1eqfyZBny4s3YlC2Tty7Yfd/OAVGfTlLBgypk=";
-                "sov-celestia-client-0.1.0" = "sha256-Z3SvuWKPz+fPwHn1Nsj6cHUdrLzVOx+PkZS6D6558Sc=";
+                "sov-celestia-client-0.1.0" = "sha256-2z2KQY1Txo6SqneXxG3nR8x4smbR+Nqv5cTqG0P3TXE=";
             };
         };
 
@@ -137,7 +137,7 @@ let
                 "curve25519-dalek-4.1.0" = "sha256-H8YMea3AIcUn9NGRfataNjCTzCK4NAjo4ZhWuPfT6ts=";
                 "risc0-cycle-utils-0.3.0" = "sha256-5dA62v1eqfyZBny4s3YlC2Tty7Yfd/OAVGfTlLBgypk=";
                 "rockbound-1.0.0" = "sha256-xTaeBndRb/bYe+tySChDKsh4f9pywAExsdgJExCQiy8=";
-                "sov-celestia-client-0.1.0" = "sha256-Z3SvuWKPz+fPwHn1Nsj6cHUdrLzVOx+PkZS6D6558Sc=";
+                "sov-celestia-client-0.1.0" = "sha256-2z2KQY1Txo6SqneXxG3nR8x4smbR+Nqv5cTqG0P3TXE=";
             };
         };
 

--- a/nix/rollup.nix
+++ b/nix/rollup.nix
@@ -97,6 +97,7 @@ let
                 "risc0-cycle-utils-0.3.0" = "sha256-5dA62v1eqfyZBny4s3YlC2Tty7Yfd/OAVGfTlLBgypk=";
                 "ibc-app-transfer-0.51.0" = "sha256-Z3zgk29JLE+pygKsbmIntVQFvC56Rg35UKKDgZH8AS4=";
                 "sov-celestia-client-0.1.0" = "sha256-PLNKgZ92SqX5q9CXE9Hff5RZ9yU6JiaWpxSTNUvUBkI=";
+                "sov-celestia-adapter-0.3.0" = "";
             };
         };
 

--- a/nix/rollup.nix
+++ b/nix/rollup.nix
@@ -51,8 +51,7 @@ let
                 "curve25519-dalek-4.1.0" = "sha256-H8YMea3AIcUn9NGRfataNjCTzCK4NAjo4ZhWuPfT6ts=";
                 "sha2-0.10.8" = "sha256-vuFQFlbDXEW+n9+Nx2VeWanggCSd6NZ+GVEDFS9qZ2M=";
                 "risc0-cycle-utils-0.3.0" = "sha256-5dA62v1eqfyZBny4s3YlC2Tty7Yfd/OAVGfTlLBgypk=";
-                "ibc-app-transfer-0.51.0" = "sha256-Z3zgk29JLE+pygKsbmIntVQFvC56Rg35UKKDgZH8AS4=";
-                "sov-celestia-client-0.1.0" = "sha256-PLNKgZ92SqX5q9CXE9Hff5RZ9yU6JiaWpxSTNUvUBkI=";
+                "sov-celestia-client-0.1.0" = "sha256-Z3SvuWKPz+fPwHn1Nsj6cHUdrLzVOx+PkZS6D6558Sc=";
             };
         };
 
@@ -95,9 +94,7 @@ let
                 "sha2-0.10.8" = "sha256-vuFQFlbDXEW+n9+Nx2VeWanggCSd6NZ+GVEDFS9qZ2M=";
                 "tendermint-0.32.0" = "sha256-FtY7a+hBvQryATrs3mykCWFRe8ABTT6cuf5oh9IBElQ=";
                 "risc0-cycle-utils-0.3.0" = "sha256-5dA62v1eqfyZBny4s3YlC2Tty7Yfd/OAVGfTlLBgypk=";
-                "ibc-app-transfer-0.51.0" = "sha256-Z3zgk29JLE+pygKsbmIntVQFvC56Rg35UKKDgZH8AS4=";
-                "sov-celestia-client-0.1.0" = "sha256-PLNKgZ92SqX5q9CXE9Hff5RZ9yU6JiaWpxSTNUvUBkI=";
-                "sov-celestia-adapter-0.3.0" = "";
+                "sov-celestia-client-0.1.0" = "sha256-Z3SvuWKPz+fPwHn1Nsj6cHUdrLzVOx+PkZS6D6558Sc=";
             };
         };
 
@@ -140,8 +137,7 @@ let
                 "curve25519-dalek-4.1.0" = "sha256-H8YMea3AIcUn9NGRfataNjCTzCK4NAjo4ZhWuPfT6ts=";
                 "risc0-cycle-utils-0.3.0" = "sha256-5dA62v1eqfyZBny4s3YlC2Tty7Yfd/OAVGfTlLBgypk=";
                 "rockbound-1.0.0" = "sha256-xTaeBndRb/bYe+tySChDKsh4f9pywAExsdgJExCQiy8=";
-                "ibc-app-transfer-0.51.0" = "sha256-Z3zgk29JLE+pygKsbmIntVQFvC56Rg35UKKDgZH8AS4=";
-                "sov-celestia-client-0.1.0" = "sha256-PLNKgZ92SqX5q9CXE9Hff5RZ9yU6JiaWpxSTNUvUBkI=";
+                "sov-celestia-client-0.1.0" = "sha256-Z3SvuWKPz+fPwHn1Nsj6cHUdrLzVOx+PkZS6D6558Sc=";
             };
         };
 


### PR DESCRIPTION
## Description

This PR incorporates the custom `sov-consensus-state-tracker` kernel module instead of using `BasicKernel`.
This kernel continuously updates the current rollup's height, timestamp, and DA consensus state that is viewed by the `sov-ibc` modules.