### PR TITLE
Update ibc-rs version

### DIFF
--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -15,8 +15,6 @@ jobs:
   nix-build:
     runs-on: ubuntu-latest
     steps:
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
       - uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: ${{ secrets.SOVEREIGN_SDK_PRIVATE_SSH_KEY }}

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -15,6 +15,8 @@ jobs:
   nix-build:
     runs-on: ubuntu-latest
     steps:
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
       - uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: ${{ secrets.SOVEREIGN_SDK_PRIVATE_SSH_KEY }}

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -15,9 +15,11 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
+  rust-build:
     runs-on: ubuntu-latest
     steps:
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
       - uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: ${{ secrets.SOVEREIGN_SDK_PRIVATE_SSH_KEY }}

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -20,6 +20,11 @@ jobs:
     steps:
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
+      - name: Set up Clang
+        uses: egor-tensin/setup-clang@v1
+        with:
+          version: latest
+          platform: x64
       - uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: ${{ secrets.SOVEREIGN_SDK_PRIVATE_SSH_KEY }}

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -18,13 +18,6 @@ jobs:
   rust-build:
     runs-on: ubuntu-latest
     steps:
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-      - name: Set up Clang
-        uses: egor-tensin/setup-clang@v1
-        with:
-          version: latest
-          platform: x64
       - uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: ${{ secrets.SOVEREIGN_SDK_PRIVATE_SSH_KEY }}

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -16,6 +16,7 @@ env:
 
 jobs:
   rust-build:
+    if: ${{ ! always() }}
     runs-on: ubuntu-latest
     steps:
       - uses: webfactory/ssh-agent@v0.9.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5348,7 +5348,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-client"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=b74f6eb#b74f6eb829d0e881f55dd8cd3fa938bf5f53e75c"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=90591e5#90591e58d89dc5c2d1b912ed1db69c2f93dbc321"
 dependencies = [
  "borsh 0.10.3",
  "derive_more",
@@ -5367,11 +5367,10 @@ dependencies = [
 [[package]]
 name = "sov-celestia-client-types"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=b74f6eb#b74f6eb829d0e881f55dd8cd3fa938bf5f53e75c"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=90591e5#90591e58d89dc5c2d1b912ed1db69c2f93dbc321"
 dependencies = [
  "derive_more",
  "ibc-client-tendermint",
- "ibc-client-wasm-types",
  "ibc-core",
  "prost",
  "serde",
@@ -5418,7 +5417,7 @@ dependencies = [
 [[package]]
 name = "sov-client-types"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=b74f6eb#b74f6eb829d0e881f55dd8cd3fa938bf5f53e75c"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=90591e5#90591e58d89dc5c2d1b912ed1db69c2f93dbc321"
 dependencies = [
  "derive_more",
  "hex",
@@ -5432,7 +5431,7 @@ dependencies = [
 [[package]]
 name = "sov-consensus-state-tracker"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=b74f6eb#b74f6eb829d0e881f55dd8cd3fa938bf5f53e75c"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=90591e5#90591e58d89dc5c2d1b912ed1db69c2f93dbc321"
 dependencies = [
  "anyhow",
  "borsh 0.10.3",
@@ -5473,7 +5472,7 @@ dependencies = [
 [[package]]
 name = "sov-ibc"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=b74f6eb#b74f6eb829d0e881f55dd8cd3fa938bf5f53e75c"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=90591e5#90591e58d89dc5c2d1b912ed1db69c2f93dbc321"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5503,7 +5502,7 @@ dependencies = [
 [[package]]
 name = "sov-ibc-proto"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=b74f6eb#b74f6eb829d0e881f55dd8cd3fa938bf5f53e75c"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=90591e5#90591e58d89dc5c2d1b912ed1db69c2f93dbc321"
 dependencies = [
  "ibc-proto 0.44.0",
  "informalsystems-pbjson",
@@ -5515,7 +5514,7 @@ dependencies = [
 [[package]]
 name = "sov-ibc-transfer"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=b74f6eb#b74f6eb829d0e881f55dd8cd3fa938bf5f53e75c"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=90591e5#90591e58d89dc5c2d1b912ed1db69c2f93dbc321"
 dependencies = [
  "anyhow",
  "borsh 0.10.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5334,7 +5334,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-client"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#88af9ef92e699cfc3561b11ffb9ff314fc32b2f9"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#982b39226670dbf7c5ce7f14d6456e1533439d30"
 dependencies = [
  "borsh",
  "derive_more",
@@ -5353,7 +5353,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-client-types"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#88af9ef92e699cfc3561b11ffb9ff314fc32b2f9"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#982b39226670dbf7c5ce7f14d6456e1533439d30"
 dependencies = [
  "derive_more",
  "ibc-client-tendermint",
@@ -5403,7 +5403,7 @@ dependencies = [
 [[package]]
 name = "sov-client-types"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#88af9ef92e699cfc3561b11ffb9ff314fc32b2f9"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#982b39226670dbf7c5ce7f14d6456e1533439d30"
 dependencies = [
  "derive_more",
  "hex",
@@ -5417,7 +5417,7 @@ dependencies = [
 [[package]]
 name = "sov-consensus-state-tracker"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#88af9ef92e699cfc3561b11ffb9ff314fc32b2f9"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#982b39226670dbf7c5ce7f14d6456e1533439d30"
 dependencies = [
  "anyhow",
  "borsh",
@@ -5458,7 +5458,7 @@ dependencies = [
 [[package]]
 name = "sov-ibc"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#88af9ef92e699cfc3561b11ffb9ff314fc32b2f9"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#982b39226670dbf7c5ce7f14d6456e1533439d30"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5488,7 +5488,7 @@ dependencies = [
 [[package]]
 name = "sov-ibc-proto"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#88af9ef92e699cfc3561b11ffb9ff314fc32b2f9"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#982b39226670dbf7c5ce7f14d6456e1533439d30"
 dependencies = [
  "ibc-proto",
  "informalsystems-pbjson",
@@ -5500,7 +5500,7 @@ dependencies = [
 [[package]]
 name = "sov-ibc-transfer"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#88af9ef92e699cfc3561b11ffb9ff314fc32b2f9"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#982b39226670dbf7c5ce7f14d6456e1533439d30"
 dependencies = [
  "anyhow",
  "borsh",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2357,7 +2357,7 @@ dependencies = [
  "http 1.1.0",
  "ibc-app-transfer-types",
  "ibc-core",
- "ibc-proto 0.45.0",
+ "ibc-proto",
  "mime",
  "parity-scale-codec",
  "scale-info",
@@ -2385,7 +2385,7 @@ dependencies = [
  "derive_more",
  "displaydoc",
  "ibc-core",
- "ibc-proto 0.45.0",
+ "ibc-proto",
  "parity-scale-codec",
  "primitive-types",
  "scale-info",
@@ -2430,7 +2430,7 @@ dependencies = [
  "ibc-core-commitment-types",
  "ibc-core-host-types",
  "ibc-primitives",
- "ibc-proto 0.45.0",
+ "ibc-proto",
  "serde",
  "tendermint 0.36.0",
  "tendermint-light-client-verifier",
@@ -2447,7 +2447,7 @@ dependencies = [
  "ibc-core-client",
  "ibc-core-host-types",
  "ibc-primitives",
- "ibc-proto 0.45.0",
+ "ibc-proto",
  "serde",
 ]
 
@@ -2504,7 +2504,7 @@ dependencies = [
  "ibc-core-connection-types",
  "ibc-core-host-types",
  "ibc-primitives",
- "ibc-proto 0.45.0",
+ "ibc-proto",
  "parity-scale-codec",
  "scale-info",
  "schemars",
@@ -2554,7 +2554,7 @@ dependencies = [
  "ibc-core-commitment-types",
  "ibc-core-host-types",
  "ibc-primitives",
- "ibc-proto 0.45.0",
+ "ibc-proto",
  "parity-scale-codec",
  "scale-info",
  "schemars",
@@ -2572,7 +2572,7 @@ dependencies = [
  "derive_more",
  "displaydoc",
  "ibc-primitives",
- "ibc-proto 0.45.0",
+ "ibc-proto",
  "ics23",
  "parity-scale-codec",
  "scale-info",
@@ -2607,7 +2607,7 @@ dependencies = [
  "ibc-core-commitment-types",
  "ibc-core-host-types",
  "ibc-primitives",
- "ibc-proto 0.45.0",
+ "ibc-proto",
  "parity-scale-codec",
  "scale-info",
  "schemars",
@@ -2646,7 +2646,7 @@ dependencies = [
  "ibc-core-host-types",
  "ibc-core-router-types",
  "ibc-primitives",
- "ibc-proto 0.45.0",
+ "ibc-proto",
  "parity-scale-codec",
  "scale-info",
  "schemars",
@@ -2689,7 +2689,7 @@ dependencies = [
  "ibc-core-handler-types",
  "ibc-core-host-types",
  "ibc-primitives",
- "ibc-proto 0.45.0",
+ "ibc-proto",
  "serde",
  "sha2 0.10.8",
  "subtle-encoding",
@@ -2735,7 +2735,7 @@ dependencies = [
  "displaydoc",
  "ibc-core-host-types",
  "ibc-primitives",
- "ibc-proto 0.45.0",
+ "ibc-proto",
  "parity-scale-codec",
  "scale-info",
  "schemars",
@@ -2762,7 +2762,7 @@ dependencies = [
  "borsh 1.5.1",
  "derive_more",
  "displaydoc",
- "ibc-proto 0.45.0",
+ "ibc-proto",
  "parity-scale-codec",
  "prost",
  "scale-info",
@@ -2770,23 +2770,6 @@ dependencies = [
  "serde",
  "tendermint 0.36.0",
  "time",
-]
-
-[[package]]
-name = "ibc-proto"
-version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66080040d5a4800d52966d55b055400f86b79c34b854b935bef03c87aacda62a"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "flex-error",
- "ics23",
- "informalsystems-pbjson",
- "prost",
- "serde",
- "subtle-encoding",
- "tendermint-proto 0.36.0",
 ]
 
 [[package]]
@@ -2818,7 +2801,7 @@ source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-par
 dependencies = [
  "displaydoc",
  "ibc",
- "ibc-proto 0.45.0",
+ "ibc-proto",
  "schemars",
  "serde",
  "tonic",
@@ -5348,7 +5331,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-client"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=90591e5#90591e58d89dc5c2d1b912ed1db69c2f93dbc321"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#ff9f3e9b5f1431a557b6a673e31c8cd264dbb59d"
 dependencies = [
  "borsh 0.10.3",
  "derive_more",
@@ -5367,7 +5350,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-client-types"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=90591e5#90591e58d89dc5c2d1b912ed1db69c2f93dbc321"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#ff9f3e9b5f1431a557b6a673e31c8cd264dbb59d"
 dependencies = [
  "derive_more",
  "ibc-client-tendermint",
@@ -5417,7 +5400,7 @@ dependencies = [
 [[package]]
 name = "sov-client-types"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=90591e5#90591e58d89dc5c2d1b912ed1db69c2f93dbc321"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#ff9f3e9b5f1431a557b6a673e31c8cd264dbb59d"
 dependencies = [
  "derive_more",
  "hex",
@@ -5431,7 +5414,7 @@ dependencies = [
 [[package]]
 name = "sov-consensus-state-tracker"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=90591e5#90591e58d89dc5c2d1b912ed1db69c2f93dbc321"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#ff9f3e9b5f1431a557b6a673e31c8cd264dbb59d"
 dependencies = [
  "anyhow",
  "borsh 0.10.3",
@@ -5472,7 +5455,7 @@ dependencies = [
 [[package]]
 name = "sov-ibc"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=90591e5#90591e58d89dc5c2d1b912ed1db69c2f93dbc321"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#ff9f3e9b5f1431a557b6a673e31c8cd264dbb59d"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5502,9 +5485,9 @@ dependencies = [
 [[package]]
 name = "sov-ibc-proto"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=90591e5#90591e58d89dc5c2d1b912ed1db69c2f93dbc321"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#ff9f3e9b5f1431a557b6a673e31c8cd264dbb59d"
 dependencies = [
- "ibc-proto 0.44.0",
+ "ibc-proto",
  "informalsystems-pbjson",
  "prost",
  "serde",
@@ -5514,7 +5497,7 @@ dependencies = [
 [[package]]
 name = "sov-ibc-transfer"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=90591e5#90591e58d89dc5c2d1b912ed1db69c2f93dbc321"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#ff9f3e9b5f1431a557b6a673e31c8cd264dbb59d"
 dependencies = [
  "anyhow",
  "borsh 0.10.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,11 +21,20 @@ checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
 dependencies = [
  "cpp_demangle",
  "fallible-iterator",
- "gimli",
+ "gimli 0.28.1",
  "memmap2",
- "object",
+ "object 0.32.2",
  "rustc-demangle",
  "smallvec",
+]
+
+[[package]]
+name = "addr2line"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
+dependencies = [
+ "gimli 0.29.0",
 ]
 
 [[package]]
@@ -113,9 +122,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a64c907d4e79225ac72e2a354c9ce84d50ebb4586dee56c82b3ee73004f537f5"
+checksum = "ad186efb764318d35165f1758e7dcef3b10628e26d41a44bc5550652e6804391"
 dependencies = [
  "windows-sys 0.52.0",
 ]
@@ -183,7 +192,7 @@ dependencies = [
  "ark-std 0.4.0",
  "derivative",
  "hashbrown 0.13.2",
- "itertools",
+ "itertools 0.10.5",
  "num-traits",
  "zeroize",
 ]
@@ -218,7 +227,7 @@ dependencies = [
  "ark-std 0.4.0",
  "derivative",
  "digest 0.10.7",
- "itertools",
+ "itertools 0.10.5",
  "num-bigint 0.4.5",
  "num-traits",
  "paste",
@@ -396,9 +405,9 @@ checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
 
 [[package]]
 name = "async-compression"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c90a406b4495d129f00461241616194cb8a032c8d1c53c657f0961d5f8e0498"
+checksum = "cd066d0b4ef8ecb03a55319dc13aa6910616d0f44008a045bb1835af830abff5"
 dependencies = [
  "flate2",
  "futures-core",
@@ -494,7 +503,7 @@ dependencies = [
  "futures-util",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.28",
+ "hyper 0.14.29",
  "itoa",
  "matchit",
  "memchr",
@@ -609,16 +618,16 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.71"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
+checksum = "17c6a35df3749d2e8bb1b7b21a976d82b15548788d2735b9d82f329268f71a11"
 dependencies = [
- "addr2line",
+ "addr2line 0.22.0",
  "cc",
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object",
+ "object 0.35.0",
  "rustc-demangle",
 ]
 
@@ -794,19 +803,9 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4114279215a005bc675e386011e594e1d9b800918cea18fcadadcce864a2046b"
 dependencies = [
- "borsh-derive 0.10.3",
+ "borsh-derive",
  "bytes",
  "hashbrown 0.13.2",
-]
-
-[[package]]
-name = "borsh"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6362ed55def622cddc70a4746a68554d7b687713770de539e59a739b249f8ed"
-dependencies = [
- "borsh-derive 1.5.1",
- "cfg_aliases",
 ]
 
 [[package]]
@@ -820,20 +819,6 @@ dependencies = [
  "proc-macro-crate 0.1.5",
  "proc-macro2",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "borsh-derive"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3ef8005764f53cd4dca619f5bf64cafd4664dada50ece25e4d81de54c80cc0b"
-dependencies = [
- "once_cell",
- "proc-macro-crate 3.1.0",
- "proc-macro2",
- "quote",
- "syn 2.0.66",
- "syn_derive",
 ]
 
 [[package]]
@@ -887,9 +872,9 @@ dependencies = [
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "369cfaf2a5bed5d8f8202073b2e093c9f508251de1551a0deb4253e4c7d80909"
+checksum = "1ee891b04274a59bd38b412188e24b849617b2e45a0fd8d057deb63e7403761b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1044,12 +1029,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "cfg_aliases"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
-
-[[package]]
 name = "chrono"
 version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1083,9 +1062,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a483f3cbf7cec2e153d424d0e92329d816becc6421389bd494375c6065921b9b"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
 dependencies = [
  "glob",
  "libc",
@@ -2001,6 +1980,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
+
+[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2214,9 +2199,9 @@ checksum = "f58b778a5761513caf593693f8951c97a5b610841e754788400f32102eefdff1"
 
 [[package]]
 name = "hyper"
-version = "0.14.28"
+version = "0.14.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
+checksum = "f361cde2f109281a220d4307746cdfd5ee3f410da58a70377762396775634b33"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2264,7 +2249,7 @@ checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
  "http 0.2.12",
- "hyper 0.14.28",
+ "hyper 0.14.29",
  "log",
  "rustls 0.21.12",
  "rustls-native-certs 0.6.3",
@@ -2278,7 +2263,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
- "hyper 0.14.28",
+ "hyper 0.14.29",
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
@@ -2286,9 +2271,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d8d52be92d09acc2e01dddb7fde3ad983fc6489c7db4837e605bc3fca4cb63e"
+checksum = "7b875924a60b96e5d7b9ae7b066540b1dd1cbd90d1828f54c92e02a283351c56"
 dependencies = [
  "bytes",
  "futures-util",
@@ -2325,7 +2310,7 @@ dependencies = [
 [[package]]
 name = "ibc"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
  "ibc-apps",
  "ibc-clients",
@@ -2338,7 +2323,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-nft-transfer"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
  "ibc-app-nft-transfer-types",
  "ibc-core",
@@ -2348,10 +2333,10 @@ dependencies = [
 [[package]]
 name = "ibc-app-nft-transfer-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
  "base64 0.21.7",
- "borsh 1.5.1",
+ "borsh",
  "derive_more",
  "displaydoc",
  "http 1.1.0",
@@ -2369,7 +2354,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
  "ibc-app-transfer-types",
  "ibc-core",
@@ -2379,9 +2364,9 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
- "borsh 1.5.1",
+ "borsh",
  "derive_more",
  "displaydoc",
  "ibc-core",
@@ -2397,7 +2382,7 @@ dependencies = [
 [[package]]
 name = "ibc-apps"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
  "ibc-app-nft-transfer",
  "ibc-app-transfer",
@@ -2406,7 +2391,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
  "derive_more",
  "ibc-client-tendermint-types",
@@ -2423,7 +2408,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
  "displaydoc",
  "ibc-core-client-types",
@@ -2440,7 +2425,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-wasm-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
  "base64 0.21.7",
  "displaydoc",
@@ -2454,7 +2439,7 @@ dependencies = [
 [[package]]
 name = "ibc-clients"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
  "ibc-client-tendermint",
  "ibc-client-wasm-types",
@@ -2463,7 +2448,7 @@ dependencies = [
 [[package]]
 name = "ibc-core"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -2479,7 +2464,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
  "ibc-core-channel-types",
  "ibc-core-client",
@@ -2494,9 +2479,9 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
- "borsh 1.5.1",
+ "borsh",
  "derive_more",
  "displaydoc",
  "ibc-core-client-types",
@@ -2517,7 +2502,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
  "ibc-core-client-context",
  "ibc-core-client-types",
@@ -2530,7 +2515,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-context"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -2546,9 +2531,9 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
- "borsh 1.5.1",
+ "borsh",
  "derive_more",
  "displaydoc",
  "ibc-core-commitment-types",
@@ -2566,9 +2551,9 @@ dependencies = [
 [[package]]
 name = "ibc-core-commitment-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
- "borsh 1.5.1",
+ "borsh",
  "derive_more",
  "displaydoc",
  "ibc-primitives",
@@ -2584,7 +2569,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-connection"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
  "ibc-client-wasm-types",
  "ibc-core-client",
@@ -2598,9 +2583,9 @@ dependencies = [
 [[package]]
 name = "ibc-core-connection-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
- "borsh 1.5.1",
+ "borsh",
  "derive_more",
  "displaydoc",
  "ibc-core-client-types",
@@ -2619,7 +2604,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -2634,9 +2619,9 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
- "borsh 1.5.1",
+ "borsh",
  "derive_more",
  "displaydoc",
  "ibc-core-channel-types",
@@ -2658,7 +2643,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -2676,7 +2661,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host-cosmos"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -2699,9 +2684,9 @@ dependencies = [
 [[package]]
 name = "ibc-core-host-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
- "borsh 1.5.1",
+ "borsh",
  "derive_more",
  "displaydoc",
  "ibc-primitives",
@@ -2714,7 +2699,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-router"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -2728,9 +2713,9 @@ dependencies = [
 [[package]]
 name = "ibc-core-router-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
- "borsh 1.5.1",
+ "borsh",
  "derive_more",
  "displaydoc",
  "ibc-core-host-types",
@@ -2747,7 +2732,7 @@ dependencies = [
 [[package]]
 name = "ibc-derive"
 version = "0.7.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2757,9 +2742,9 @@ dependencies = [
 [[package]]
 name = "ibc-primitives"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
- "borsh 1.5.1",
+ "borsh",
  "derive_more",
  "displaydoc",
  "ibc-proto",
@@ -2774,12 +2759,12 @@ dependencies = [
 
 [[package]]
 name = "ibc-proto"
-version = "0.45.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7002e679ad26dc29bd27dfa490bb689d121d03c1512bed9f646f75028165644d"
+checksum = "66080040d5a4800d52966d55b055400f86b79c34b854b935bef03c87aacda62a"
 dependencies = [
  "base64 0.22.1",
- "borsh 1.5.1",
+ "borsh",
  "bytes",
  "flex-error",
  "ics23",
@@ -2797,7 +2782,7 @@ dependencies = [
 [[package]]
 name = "ibc-query"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
  "displaydoc",
  "ibc",
@@ -2949,6 +2934,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2960,12 +2954,12 @@ version = "0.9.0"
 source = "git+https://github.com/penumbra-zone/jmt.git?rev=1d007e11cb68aa5ca13e9a5af4a12e6439d5f7b6#1d007e11cb68aa5ca13e9a5af4a12e6439d5f7b6"
 dependencies = [
  "anyhow",
- "borsh 0.10.3",
+ "borsh",
  "digest 0.10.7",
  "hashbrown 0.13.2",
  "hex",
  "ics23",
- "itertools",
+ "itertools 0.10.5",
  "mirai-annotations",
  "num-derive 0.3.3",
  "num-traits",
@@ -3066,7 +3060,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "url",
- "webpki-roots 0.26.1",
+ "webpki-roots 0.26.2",
 ]
 
 [[package]]
@@ -3081,7 +3075,7 @@ dependencies = [
  "beef",
  "futures-timer",
  "futures-util",
- "hyper 0.14.28",
+ "hyper 0.14.29",
  "jsonrpsee-types 0.20.3",
  "rustc-hash",
  "serde",
@@ -3102,7 +3096,7 @@ dependencies = [
  "beef",
  "futures-timer",
  "futures-util",
- "hyper 0.14.28",
+ "hyper 0.14.29",
  "jsonrpsee-types 0.22.5",
  "parking_lot",
  "pin-project",
@@ -3124,7 +3118,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f80c17f62c7653ce767e3d7288b793dfec920f97067ceb189ebdd3570f2bc20"
 dependencies = [
  "async-trait",
- "hyper 0.14.28",
+ "hyper 0.14.29",
  "hyper-rustls",
  "jsonrpsee-core 0.20.3",
  "jsonrpsee-types 0.20.3",
@@ -3144,7 +3138,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ccf93fc4a0bfe05d851d37d7c32b7f370fe94336b52a2f0efc5f1981895c2e5"
 dependencies = [
  "async-trait",
- "hyper 0.14.28",
+ "hyper 0.14.29",
  "hyper-rustls",
  "jsonrpsee-core 0.22.5",
  "jsonrpsee-types 0.22.5",
@@ -3191,7 +3185,7 @@ checksum = "12d8b6a9674422a8572e0b0abb12feeb3f2aeda86528c80d0350c2bd0923ab41"
 dependencies = [
  "futures-util",
  "http 0.2.12",
- "hyper 0.14.28",
+ "hyper 0.14.29",
  "jsonrpsee-core 0.22.5",
  "jsonrpsee-types 0.22.5",
  "pin-project",
@@ -3570,7 +3564,7 @@ name = "nmt-rs"
 version = "0.1.0"
 source = "git+https://github.com/Sovereign-Labs/nmt-rs.git?rev=d821332#d821332baa03aea625d23060dc239af57b9121f5"
 dependencies = [
- "borsh 0.10.3",
+ "borsh",
  "bytes",
  "serde",
  "sha2 0.10.8",
@@ -3686,6 +3680,15 @@ dependencies = [
  "flate2",
  "memchr",
  "ruzstd",
+]
+
+[[package]]
+name = "object"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8ec7ab813848ba4522158d5517a6093db1ded27575b070f4177b8d12b41db5e"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -3952,9 +3955,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.84"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec96c6a92621310b51366f1e28d05ef11489516e93be030060e5fc12024a49d6"
+checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
 dependencies = [
  "unicode-ident",
 ]
@@ -4022,7 +4025,7 @@ checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
  "heck 0.5.0",
- "itertools",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "once_cell",
@@ -4042,7 +4045,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.66",
@@ -4241,7 +4244,7 @@ dependencies = [
  "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.28",
+ "hyper 0.14.29",
  "hyper-rustls",
  "ipnet",
  "js-sys",
@@ -4464,7 +4467,7 @@ version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "922588cb4b884b3951316a65581ccdfd1174af93c54093190878366812073329"
 dependencies = [
- "addr2line",
+ "addr2line 0.21.0",
  "anyhow",
  "ark-bn254",
  "ark-groth16",
@@ -4565,9 +4568,9 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.12.1"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f308135fef9fc398342da5472ce7c484529df23743fb7c734e0f3d472971e62"
+checksum = "2c3cc4c2511671f327125da14133d0c5c5d137f006a1017a16f557bc85b16286"
 dependencies = [
  "alloy-rlp",
  "ark-ff 0.3.0",
@@ -4589,9 +4592,9 @@ dependencies = [
 
 [[package]]
 name = "ruint-macro"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f86854cf50259291520509879a5c294c3c9a4c334e9ff65071c51e42ef1e2343"
+checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 
 [[package]]
 name = "rust-embed"
@@ -5247,7 +5250,7 @@ name = "sov-accounts"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "borsh 0.10.3",
+ "borsh",
  "jsonrpsee 0.22.5",
  "schemars",
  "serde",
@@ -5262,7 +5265,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "bech32 0.11.0",
- "borsh 0.10.3",
+ "borsh",
  "jsonrpsee 0.22.5",
  "schemars",
  "serde",
@@ -5277,7 +5280,7 @@ name = "sov-blob-storage"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "borsh 0.10.3",
+ "borsh",
  "hex",
  "serde",
  "sov-chain-state",
@@ -5308,7 +5311,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bech32 0.9.1",
- "borsh 0.10.3",
+ "borsh",
  "celestia-proto",
  "celestia-rpc",
  "celestia-types",
@@ -5331,9 +5334,9 @@ dependencies = [
 [[package]]
 name = "sov-celestia-client"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#ff9f3e9b5f1431a557b6a673e31c8cd264dbb59d"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#88af9ef92e699cfc3561b11ffb9ff314fc32b2f9"
 dependencies = [
- "borsh 0.10.3",
+ "borsh",
  "derive_more",
  "ibc-client-tendermint",
  "ibc-core",
@@ -5350,7 +5353,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-client-types"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#ff9f3e9b5f1431a557b6a673e31c8cd264dbb59d"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#88af9ef92e699cfc3561b11ffb9ff314fc32b2f9"
 dependencies = [
  "derive_more",
  "ibc-client-tendermint",
@@ -5369,7 +5372,7 @@ name = "sov-chain-state"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "borsh 0.10.3",
+ "borsh",
  "derivative",
  "jsonrpsee 0.22.5",
  "serde",
@@ -5384,7 +5387,7 @@ name = "sov-cli"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "borsh 0.10.3",
+ "borsh",
  "directories",
  "hex",
  "jsonrpsee 0.22.5",
@@ -5400,7 +5403,7 @@ dependencies = [
 [[package]]
 name = "sov-client-types"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#ff9f3e9b5f1431a557b6a673e31c8cd264dbb59d"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#88af9ef92e699cfc3561b11ffb9ff314fc32b2f9"
 dependencies = [
  "derive_more",
  "hex",
@@ -5414,10 +5417,10 @@ dependencies = [
 [[package]]
 name = "sov-consensus-state-tracker"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#ff9f3e9b5f1431a557b6a673e31c8cd264dbb59d"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#88af9ef92e699cfc3561b11ffb9ff314fc32b2f9"
 dependencies = [
  "anyhow",
- "borsh 0.10.3",
+ "borsh",
  "ibc-app-transfer",
  "ibc-core",
  "prost",
@@ -5441,7 +5444,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bincode",
- "borsh 0.10.3",
+ "borsh",
  "byteorder",
  "hex",
  "jmt",
@@ -5455,12 +5458,12 @@ dependencies = [
 [[package]]
 name = "sov-ibc"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#ff9f3e9b5f1431a557b6a673e31c8cd264dbb59d"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#88af9ef92e699cfc3561b11ffb9ff314fc32b2f9"
 dependencies = [
  "ahash",
  "anyhow",
  "base64 0.21.7",
- "borsh 0.10.3",
+ "borsh",
  "derive_more",
  "ibc-app-transfer",
  "ibc-client-tendermint",
@@ -5485,7 +5488,7 @@ dependencies = [
 [[package]]
 name = "sov-ibc-proto"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#ff9f3e9b5f1431a557b6a673e31c8cd264dbb59d"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#88af9ef92e699cfc3561b11ffb9ff314fc32b2f9"
 dependencies = [
  "ibc-proto",
  "informalsystems-pbjson",
@@ -5497,10 +5500,10 @@ dependencies = [
 [[package]]
 name = "sov-ibc-transfer"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#ff9f3e9b5f1431a557b6a673e31c8cd264dbb59d"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#88af9ef92e699cfc3561b11ffb9ff314fc32b2f9"
 dependencies = [
  "anyhow",
- "borsh 0.10.3",
+ "borsh",
  "derive_more",
  "ibc-app-transfer",
  "ibc-core",
@@ -5533,7 +5536,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "axum 0.7.5",
- "borsh 0.10.3",
+ "borsh",
  "futures",
  "hex",
  "jsonrpsee 0.22.5",
@@ -5564,7 +5567,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "borsh 0.10.3",
+ "borsh",
  "bytes",
  "futures",
  "hex",
@@ -5583,7 +5586,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "bincode",
- "borsh 0.10.3",
+ "borsh",
  "digest 0.10.7",
  "ed25519-dalek 2.1.1",
  "hex",
@@ -5602,7 +5605,7 @@ dependencies = [
  "async-trait",
  "axum 0.7.5",
  "bech32 0.11.0",
- "borsh 0.10.3",
+ "borsh",
  "clap",
  "derivative",
  "derive_more",
@@ -5647,7 +5650,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "axum 0.7.5",
- "borsh 0.10.3",
+ "borsh",
  "jsonrpsee 0.22.5",
  "serde",
  "serde_json",
@@ -5670,7 +5673,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "axum 0.7.5",
- "borsh 0.10.3",
+ "borsh",
  "hex",
  "jsonrpsee 0.22.5",
  "serde",
@@ -5687,7 +5690,7 @@ name = "sov-prover-incentives"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "borsh 0.10.3",
+ "borsh",
  "jsonrpsee 0.22.5",
  "schemars",
  "serde",
@@ -5734,7 +5737,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "bincode",
- "borsh 0.10.3",
+ "borsh",
  "bytemuck",
  "crypto-bigint",
  "digest 0.10.7",
@@ -5759,7 +5762,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "borsh 0.10.3",
+ "borsh",
  "bytes",
  "digest 0.10.7",
  "futures",
@@ -5777,7 +5780,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "axum 0.7.5",
- "borsh 0.10.3",
+ "borsh",
  "bytes",
  "clap",
  "jsonrpsee 0.22.5",
@@ -5824,7 +5827,7 @@ dependencies = [
  "axum-server",
  "base64 0.22.1",
  "bincode",
- "borsh 0.10.3",
+ "borsh",
  "dashmap",
  "hex",
  "jsonrpsee 0.22.5",
@@ -5850,7 +5853,7 @@ name = "sov-sequencer-registry"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "borsh 0.10.3",
+ "borsh",
  "jsonrpsee 0.22.5",
  "risc0-cycle-utils",
  "schemars",
@@ -5868,7 +5871,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "bcs",
- "borsh 0.10.3",
+ "borsh",
  "derivative",
  "hex",
  "jmt",
@@ -5886,7 +5889,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "axum 0.7.5",
- "borsh 0.10.3",
+ "borsh",
  "derivative",
  "futures",
  "hex",
@@ -5901,7 +5904,7 @@ dependencies = [
  "strum",
  "thiserror",
  "tokio",
- "toml 0.8.13",
+ "toml 0.8.14",
  "tracing",
 ]
 
@@ -5938,7 +5941,7 @@ name = "stf-starter"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "borsh 0.10.3",
+ "borsh",
  "clap",
  "jsonrpsee 0.22.5",
  "serde",
@@ -5983,11 +5986,11 @@ dependencies = [
 
 [[package]]
 name = "strum_macros"
-version = "0.26.2"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6cf59daf282c0a494ba14fd21610a0325f9f90ec9d1231dea26bcb1d696c946"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -6035,18 +6038,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "syn_derive"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1329189c02ff984e9736652b1631330da25eaa6bc639089ed4915d25446cbe7b"
-dependencies = [
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 2.0.66",
 ]
 
 [[package]]
@@ -6310,9 +6301,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.37.0"
+version = "1.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
+checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
 dependencies = [
  "backtrace",
  "bytes",
@@ -6339,9 +6330,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6418,14 +6409,14 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.13"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4e43f8cc456c9704c851ae29c67e17ef65d2c30017c17a9765b89c382dc8bba"
+checksum = "6f49eb2ab21d2f26bd6db7bf383edc527a7ebaee412d17af4d40fdccd442f335"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.13",
+ "toml_edit 0.22.14",
 ]
 
 [[package]]
@@ -6450,15 +6441,15 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.13"
+version = "0.22.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c127785850e8c20836d49732ae6abfa47616e60bf9d9f57c43c250361a9db96c"
+checksum = "f21c7aaf97f1bd9ca9d4f9e73b0a6c74bd5afef56f2bc931943a6e1c37e04e38"
 dependencies = [
  "indexmap 2.2.6",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.8",
+ "winnow 0.6.11",
 ]
 
 [[package]]
@@ -6475,7 +6466,7 @@ dependencies = [
  "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.28",
+ "hyper 0.14.29",
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
@@ -6638,9 +6629,9 @@ dependencies = [
 
 [[package]]
 name = "triomphe"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "859eb650cfee7434994602c3a68b25d77ad9e68c8a6cd491616ef86661382eb3"
+checksum = "1b2cb4fbb9995eeb36ac86fadf24031ccd58f99d6b4b2d7b911db70bddb80d90"
 
 [[package]]
 name = "try-lock"
@@ -7033,9 +7024,9 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3de34ae270483955a94f4b21bdaaeb83d508bb84a01435f393818edb0012009"
+checksum = "3c452ad30530b54a4d8e71952716a212b08efd0f3562baa66c29a618b07da7c3"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -7230,9 +7221,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c52e9c97a68071b23e836c9380edae937f17b9c4667bd021973efc689f618d"
+checksum = "56c52728401e1dc672a56e81e593e912aa54c78f40246869f78359a2bf24d29d"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,7 +183,7 @@ dependencies = [
  "ark-std 0.4.0",
  "derivative",
  "hashbrown 0.13.2",
- "itertools 0.10.5",
+ "itertools",
  "num-traits",
  "zeroize",
 ]
@@ -218,7 +218,7 @@ dependencies = [
  "ark-std 0.4.0",
  "derivative",
  "digest 0.10.7",
- "itertools 0.10.5",
+ "itertools",
  "num-bigint 0.4.5",
  "num-traits",
  "paste",
@@ -794,9 +794,19 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4114279215a005bc675e386011e594e1d9b800918cea18fcadadcce864a2046b"
 dependencies = [
- "borsh-derive",
+ "borsh-derive 0.10.3",
  "bytes",
  "hashbrown 0.13.2",
+]
+
+[[package]]
+name = "borsh"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6362ed55def622cddc70a4746a68554d7b687713770de539e59a739b249f8ed"
+dependencies = [
+ "borsh-derive 1.5.1",
+ "cfg_aliases",
 ]
 
 [[package]]
@@ -810,6 +820,20 @@ dependencies = [
  "proc-macro-crate 0.1.5",
  "proc-macro2",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3ef8005764f53cd4dca619f5bf64cafd4664dada50ece25e4d81de54c80cc0b"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate 3.1.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+ "syn_derive",
 ]
 
 [[package]]
@@ -1018,6 +1042,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -2295,7 +2325,7 @@ dependencies = [
 [[package]]
 name = "ibc"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
  "ibc-apps",
  "ibc-clients",
@@ -2308,7 +2338,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-nft-transfer"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
  "ibc-app-nft-transfer-types",
  "ibc-core",
@@ -2318,16 +2348,16 @@ dependencies = [
 [[package]]
 name = "ibc-app-nft-transfer-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
  "base64 0.21.7",
- "borsh",
+ "borsh 1.5.1",
  "derive_more",
  "displaydoc",
  "http 1.1.0",
  "ibc-app-transfer-types",
  "ibc-core",
- "ibc-proto",
+ "ibc-proto 0.45.0",
  "mime",
  "parity-scale-codec",
  "scale-info",
@@ -2339,7 +2369,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
  "ibc-app-transfer-types",
  "ibc-core",
@@ -2349,13 +2379,13 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
- "borsh",
+ "borsh 1.5.1",
  "derive_more",
  "displaydoc",
  "ibc-core",
- "ibc-proto",
+ "ibc-proto 0.45.0",
  "parity-scale-codec",
  "primitive-types",
  "scale-info",
@@ -2367,7 +2397,7 @@ dependencies = [
 [[package]]
 name = "ibc-apps"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
  "ibc-app-nft-transfer",
  "ibc-app-transfer",
@@ -2376,7 +2406,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
  "derive_more",
  "ibc-client-tendermint-types",
@@ -2393,14 +2423,14 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
  "displaydoc",
  "ibc-core-client-types",
  "ibc-core-commitment-types",
  "ibc-core-host-types",
  "ibc-primitives",
- "ibc-proto",
+ "ibc-proto 0.45.0",
  "serde",
  "tendermint 0.36.0",
  "tendermint-light-client-verifier",
@@ -2410,21 +2440,21 @@ dependencies = [
 [[package]]
 name = "ibc-client-wasm-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
  "base64 0.21.7",
  "displaydoc",
  "ibc-core-client",
  "ibc-core-host-types",
  "ibc-primitives",
- "ibc-proto",
+ "ibc-proto 0.45.0",
  "serde",
 ]
 
 [[package]]
 name = "ibc-clients"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
  "ibc-client-tendermint",
  "ibc-client-wasm-types",
@@ -2433,7 +2463,7 @@ dependencies = [
 [[package]]
 name = "ibc-core"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -2449,7 +2479,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
  "ibc-core-channel-types",
  "ibc-core-client",
@@ -2464,9 +2494,9 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
- "borsh",
+ "borsh 1.5.1",
  "derive_more",
  "displaydoc",
  "ibc-core-client-types",
@@ -2474,7 +2504,7 @@ dependencies = [
  "ibc-core-connection-types",
  "ibc-core-host-types",
  "ibc-primitives",
- "ibc-proto",
+ "ibc-proto 0.45.0",
  "parity-scale-codec",
  "scale-info",
  "schemars",
@@ -2487,7 +2517,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
  "ibc-core-client-context",
  "ibc-core-client-types",
@@ -2500,7 +2530,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-context"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -2516,15 +2546,15 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
- "borsh",
+ "borsh 1.5.1",
  "derive_more",
  "displaydoc",
  "ibc-core-commitment-types",
  "ibc-core-host-types",
  "ibc-primitives",
- "ibc-proto",
+ "ibc-proto 0.45.0",
  "parity-scale-codec",
  "scale-info",
  "schemars",
@@ -2536,13 +2566,13 @@ dependencies = [
 [[package]]
 name = "ibc-core-commitment-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
- "borsh",
+ "borsh 1.5.1",
  "derive_more",
  "displaydoc",
  "ibc-primitives",
- "ibc-proto",
+ "ibc-proto 0.45.0",
  "ics23",
  "parity-scale-codec",
  "scale-info",
@@ -2554,28 +2584,30 @@ dependencies = [
 [[package]]
 name = "ibc-core-connection"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
+ "ibc-client-wasm-types",
  "ibc-core-client",
  "ibc-core-connection-types",
  "ibc-core-handler-types",
  "ibc-core-host",
  "ibc-primitives",
+ "prost",
 ]
 
 [[package]]
 name = "ibc-core-connection-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
- "borsh",
+ "borsh 1.5.1",
  "derive_more",
  "displaydoc",
  "ibc-core-client-types",
  "ibc-core-commitment-types",
  "ibc-core-host-types",
  "ibc-primitives",
- "ibc-proto",
+ "ibc-proto 0.45.0",
  "parity-scale-codec",
  "scale-info",
  "schemars",
@@ -2587,7 +2619,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -2602,9 +2634,9 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
- "borsh",
+ "borsh 1.5.1",
  "derive_more",
  "displaydoc",
  "ibc-core-channel-types",
@@ -2614,7 +2646,7 @@ dependencies = [
  "ibc-core-host-types",
  "ibc-core-router-types",
  "ibc-primitives",
- "ibc-proto",
+ "ibc-proto 0.45.0",
  "parity-scale-codec",
  "scale-info",
  "schemars",
@@ -2626,7 +2658,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -2644,7 +2676,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host-cosmos"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -2657,7 +2689,7 @@ dependencies = [
  "ibc-core-handler-types",
  "ibc-core-host-types",
  "ibc-primitives",
- "ibc-proto",
+ "ibc-proto 0.45.0",
  "serde",
  "sha2 0.10.8",
  "subtle-encoding",
@@ -2667,9 +2699,9 @@ dependencies = [
 [[package]]
 name = "ibc-core-host-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
- "borsh",
+ "borsh 1.5.1",
  "derive_more",
  "displaydoc",
  "ibc-primitives",
@@ -2682,7 +2714,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-router"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -2696,14 +2728,14 @@ dependencies = [
 [[package]]
 name = "ibc-core-router-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
- "borsh",
+ "borsh 1.5.1",
  "derive_more",
  "displaydoc",
  "ibc-core-host-types",
  "ibc-primitives",
- "ibc-proto",
+ "ibc-proto 0.45.0",
  "parity-scale-codec",
  "scale-info",
  "schemars",
@@ -2715,7 +2747,7 @@ dependencies = [
 [[package]]
 name = "ibc-derive"
 version = "0.7.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2725,12 +2757,12 @@ dependencies = [
 [[package]]
 name = "ibc-primitives"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
- "borsh",
+ "borsh 1.5.1",
  "derive_more",
  "displaydoc",
- "ibc-proto",
+ "ibc-proto 0.45.0",
  "parity-scale-codec",
  "prost",
  "scale-info",
@@ -2747,7 +2779,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66080040d5a4800d52966d55b055400f86b79c34b854b935bef03c87aacda62a"
 dependencies = [
  "base64 0.22.1",
- "borsh",
+ "bytes",
+ "flex-error",
+ "ics23",
+ "informalsystems-pbjson",
+ "prost",
+ "serde",
+ "subtle-encoding",
+ "tendermint-proto 0.36.0",
+]
+
+[[package]]
+name = "ibc-proto"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7002e679ad26dc29bd27dfa490bb689d121d03c1512bed9f646f75028165644d"
+dependencies = [
+ "base64 0.22.1",
+ "borsh 1.5.1",
  "bytes",
  "flex-error",
  "ics23",
@@ -2765,11 +2814,11 @@ dependencies = [
 [[package]]
 name = "ibc-query"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
  "displaydoc",
  "ibc",
- "ibc-proto",
+ "ibc-proto 0.45.0",
  "schemars",
  "serde",
  "tonic",
@@ -2917,15 +2966,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2937,12 +2977,12 @@ version = "0.9.0"
 source = "git+https://github.com/penumbra-zone/jmt.git?rev=1d007e11cb68aa5ca13e9a5af4a12e6439d5f7b6#1d007e11cb68aa5ca13e9a5af4a12e6439d5f7b6"
 dependencies = [
  "anyhow",
- "borsh",
+ "borsh 0.10.3",
  "digest 0.10.7",
  "hashbrown 0.13.2",
  "hex",
  "ics23",
- "itertools 0.10.5",
+ "itertools",
  "mirai-annotations",
  "num-derive 0.3.3",
  "num-traits",
@@ -3547,7 +3587,7 @@ name = "nmt-rs"
 version = "0.1.0"
 source = "git+https://github.com/Sovereign-Labs/nmt-rs.git?rev=d821332#d821332baa03aea625d23060dc239af57b9121f5"
 dependencies = [
- "borsh",
+ "borsh 0.10.3",
  "bytes",
  "serde",
  "sha2 0.10.8",
@@ -3999,7 +4039,7 @@ checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
  "heck 0.5.0",
- "itertools 0.12.1",
+ "itertools",
  "log",
  "multimap",
  "once_cell",
@@ -4019,7 +4059,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools",
  "proc-macro2",
  "quote",
  "syn 2.0.66",
@@ -5224,7 +5264,7 @@ name = "sov-accounts"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "borsh",
+ "borsh 0.10.3",
  "jsonrpsee 0.22.5",
  "schemars",
  "serde",
@@ -5239,7 +5279,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "bech32 0.11.0",
- "borsh",
+ "borsh 0.10.3",
  "jsonrpsee 0.22.5",
  "schemars",
  "serde",
@@ -5254,7 +5294,7 @@ name = "sov-blob-storage"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "borsh",
+ "borsh 0.10.3",
  "hex",
  "serde",
  "sov-chain-state",
@@ -5285,7 +5325,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bech32 0.9.1",
- "borsh",
+ "borsh 0.10.3",
  "celestia-proto",
  "celestia-rpc",
  "celestia-types",
@@ -5310,7 +5350,7 @@ name = "sov-celestia-client"
 version = "0.1.0"
 source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=b74f6eb#b74f6eb829d0e881f55dd8cd3fa938bf5f53e75c"
 dependencies = [
- "borsh",
+ "borsh 0.10.3",
  "derive_more",
  "ibc-client-tendermint",
  "ibc-core",
@@ -5347,7 +5387,7 @@ name = "sov-chain-state"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "borsh",
+ "borsh 0.10.3",
  "derivative",
  "jsonrpsee 0.22.5",
  "serde",
@@ -5362,7 +5402,7 @@ name = "sov-cli"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "borsh",
+ "borsh 0.10.3",
  "directories",
  "hex",
  "jsonrpsee 0.22.5",
@@ -5395,7 +5435,7 @@ version = "0.1.0"
 source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=b74f6eb#b74f6eb829d0e881f55dd8cd3fa938bf5f53e75c"
 dependencies = [
  "anyhow",
- "borsh",
+ "borsh 0.10.3",
  "ibc-app-transfer",
  "ibc-core",
  "prost",
@@ -5419,7 +5459,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bincode",
- "borsh",
+ "borsh 0.10.3",
  "byteorder",
  "hex",
  "jmt",
@@ -5438,7 +5478,7 @@ dependencies = [
  "ahash",
  "anyhow",
  "base64 0.21.7",
- "borsh",
+ "borsh 0.10.3",
  "derive_more",
  "ibc-app-transfer",
  "ibc-client-tendermint",
@@ -5465,7 +5505,7 @@ name = "sov-ibc-proto"
 version = "0.1.0"
 source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=b74f6eb#b74f6eb829d0e881f55dd8cd3fa938bf5f53e75c"
 dependencies = [
- "ibc-proto",
+ "ibc-proto 0.44.0",
  "informalsystems-pbjson",
  "prost",
  "serde",
@@ -5478,7 +5518,7 @@ version = "0.1.0"
 source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=b74f6eb#b74f6eb829d0e881f55dd8cd3fa938bf5f53e75c"
 dependencies = [
  "anyhow",
- "borsh",
+ "borsh 0.10.3",
  "derive_more",
  "ibc-app-transfer",
  "ibc-core",
@@ -5511,7 +5551,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "axum 0.7.5",
- "borsh",
+ "borsh 0.10.3",
  "futures",
  "hex",
  "jsonrpsee 0.22.5",
@@ -5542,7 +5582,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "borsh",
+ "borsh 0.10.3",
  "bytes",
  "futures",
  "hex",
@@ -5561,7 +5601,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "bincode",
- "borsh",
+ "borsh 0.10.3",
  "digest 0.10.7",
  "ed25519-dalek 2.1.1",
  "hex",
@@ -5580,7 +5620,7 @@ dependencies = [
  "async-trait",
  "axum 0.7.5",
  "bech32 0.11.0",
- "borsh",
+ "borsh 0.10.3",
  "clap",
  "derivative",
  "derive_more",
@@ -5625,7 +5665,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "axum 0.7.5",
- "borsh",
+ "borsh 0.10.3",
  "jsonrpsee 0.22.5",
  "serde",
  "serde_json",
@@ -5648,7 +5688,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "axum 0.7.5",
- "borsh",
+ "borsh 0.10.3",
  "hex",
  "jsonrpsee 0.22.5",
  "serde",
@@ -5665,7 +5705,7 @@ name = "sov-prover-incentives"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "borsh",
+ "borsh 0.10.3",
  "jsonrpsee 0.22.5",
  "schemars",
  "serde",
@@ -5712,7 +5752,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "bincode",
- "borsh",
+ "borsh 0.10.3",
  "bytemuck",
  "crypto-bigint",
  "digest 0.10.7",
@@ -5737,7 +5777,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "borsh",
+ "borsh 0.10.3",
  "bytes",
  "digest 0.10.7",
  "futures",
@@ -5755,7 +5795,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "axum 0.7.5",
- "borsh",
+ "borsh 0.10.3",
  "bytes",
  "clap",
  "jsonrpsee 0.22.5",
@@ -5802,7 +5842,7 @@ dependencies = [
  "axum-server",
  "base64 0.22.1",
  "bincode",
- "borsh",
+ "borsh 0.10.3",
  "dashmap",
  "hex",
  "jsonrpsee 0.22.5",
@@ -5828,7 +5868,7 @@ name = "sov-sequencer-registry"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "borsh",
+ "borsh 0.10.3",
  "jsonrpsee 0.22.5",
  "risc0-cycle-utils",
  "schemars",
@@ -5846,7 +5886,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "bcs",
- "borsh",
+ "borsh 0.10.3",
  "derivative",
  "hex",
  "jmt",
@@ -5864,7 +5904,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "axum 0.7.5",
- "borsh",
+ "borsh 0.10.3",
  "derivative",
  "futures",
  "hex",
@@ -5916,7 +5956,7 @@ name = "stf-starter"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "borsh",
+ "borsh 0.10.3",
  "clap",
  "jsonrpsee 0.22.5",
  "serde",
@@ -6013,6 +6053,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "syn_derive"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1329189c02ff984e9736652b1631330da25eaa6bc639089ed4915d25446cbe7b"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,10 +77,10 @@ ibc-app-transfer            = { git = "https://github.com/cosmos/ibc-rs.git", br
 ibc-primitives              = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/allow-country-party-client-state-wrapper" }
 ibc-query                   = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/allow-country-party-client-state-wrapper" }
 
-sov-ibc                     = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "b74f6eb"  }
-sov-ibc-transfer            = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "b74f6eb"  }
-sov-celestia-client         = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "b74f6eb"  }
-sov-consensus-state-tracker = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "b74f6eb"  }
+sov-ibc                     = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "90591e5"  }
+sov-ibc-transfer            = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "90591e5"  }
+sov-celestia-client         = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "90591e5"  }
+sov-consensus-state-tracker = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "90591e5"  }
 
 sov-modules-api                 = { path = "./vendor/sovereign-sdk/module-system/sov-modules-api" }
 sov-state                       = { path = "./vendor/sovereign-sdk/module-system/sov-state" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,14 +68,14 @@ jsonrpsee = { version = "0.22.5", features = ["jsonrpsee-types"] }
 risc0-build = "0.20"
 
 [patch.crates-io]
-ibc-core                    = { git = "https://github.com/cosmos/ibc-rs.git", rev = "67841b3c" }
-ibc-core-client             = { git = "https://github.com/cosmos/ibc-rs.git", rev = "67841b3c" }
-ibc-core-host-cosmos        = { git = "https://github.com/cosmos/ibc-rs.git", rev = "67841b3c" }
-ibc-client-tendermint       = { git = "https://github.com/cosmos/ibc-rs.git", rev = "67841b3c" }
-ibc-client-wasm-types       = { git = "https://github.com/cosmos/ibc-rs.git", rev = "67841b3c" }
-ibc-app-transfer            = { git = "https://github.com/cosmos/ibc-rs.git", rev = "67841b3c" }
-ibc-primitives              = { git = "https://github.com/cosmos/ibc-rs.git", rev = "67841b3c" }
-ibc-query                   = { git = "https://github.com/cosmos/ibc-rs.git", rev = "67841b3c" }
+ibc-core                    = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/allow-country-party-client-state-wrapper" }
+ibc-core-client             = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/allow-country-party-client-state-wrapper" }
+ibc-core-host-cosmos        = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/allow-country-party-client-state-wrapper" }
+ibc-client-tendermint       = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/allow-country-party-client-state-wrapper" }
+ibc-client-wasm-types       = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/allow-country-party-client-state-wrapper" }
+ibc-app-transfer            = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/allow-country-party-client-state-wrapper" }
+ibc-primitives              = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/allow-country-party-client-state-wrapper" }
+ibc-query                   = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/allow-country-party-client-state-wrapper" }
 
 sov-ibc                     = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "b74f6eb"  }
 sov-ibc-transfer            = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "b74f6eb"  }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,14 +68,14 @@ jsonrpsee = { version = "0.22.5", features = ["jsonrpsee-types"] }
 risc0-build = "0.20"
 
 [patch.crates-io]
-ibc-core                    = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/allow-country-party-client-state-wrapper" }
-ibc-core-client             = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/allow-country-party-client-state-wrapper" }
-ibc-core-host-cosmos        = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/allow-country-party-client-state-wrapper" }
-ibc-client-tendermint       = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/allow-country-party-client-state-wrapper" }
-ibc-client-wasm-types       = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/allow-country-party-client-state-wrapper" }
-ibc-app-transfer            = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/allow-country-party-client-state-wrapper" }
-ibc-primitives              = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/allow-country-party-client-state-wrapper" }
-ibc-query                   = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/allow-country-party-client-state-wrapper" }
+ibc-core                    = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/downgrade-borsh" }
+ibc-core-client             = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/downgrade-borsh" }
+ibc-core-host-cosmos        = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/downgrade-borsh" }
+ibc-client-tendermint       = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/downgrade-borsh" }
+ibc-client-wasm-types       = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/downgrade-borsh" }
+ibc-app-transfer            = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/downgrade-borsh" }
+ibc-primitives              = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/downgrade-borsh" }
+ibc-query                   = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/downgrade-borsh" }
 
 sov-ibc                     = { git = "https://github.com/informalsystems/sovereign-ibc.git", branch = "soares/update-ibc-rs"  }
 sov-ibc-transfer            = { git = "https://github.com/informalsystems/sovereign-ibc.git", branch = "soares/update-ibc-rs"  }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,10 +77,10 @@ ibc-app-transfer            = { git = "https://github.com/cosmos/ibc-rs.git", br
 ibc-primitives              = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/allow-country-party-client-state-wrapper" }
 ibc-query                   = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/allow-country-party-client-state-wrapper" }
 
-sov-ibc                     = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "90591e5"  }
-sov-ibc-transfer            = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "90591e5"  }
-sov-celestia-client         = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "90591e5"  }
-sov-consensus-state-tracker = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "90591e5"  }
+sov-ibc                     = { git = "https://github.com/informalsystems/sovereign-ibc.git", branch = "soares/update-ibc-rs"  }
+sov-ibc-transfer            = { git = "https://github.com/informalsystems/sovereign-ibc.git", branch = "soares/update-ibc-rs"  }
+sov-celestia-client         = { git = "https://github.com/informalsystems/sovereign-ibc.git", branch = "soares/update-ibc-rs"  }
+sov-consensus-state-tracker = { git = "https://github.com/informalsystems/sovereign-ibc.git", branch = "soares/update-ibc-rs"  }
 
 sov-modules-api                 = { path = "./vendor/sovereign-sdk/module-system/sov-modules-api" }
 sov-state                       = { path = "./vendor/sovereign-sdk/module-system/sov-state" }

--- a/crates/provers/risc0/guest-celestia/Cargo.lock
+++ b/crates/provers/risc0/guest-celestia/Cargo.lock
@@ -2783,7 +2783,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-client"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#88af9ef92e699cfc3561b11ffb9ff314fc32b2f9"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#982b39226670dbf7c5ce7f14d6456e1533439d30"
 dependencies = [
  "borsh",
  "derive_more",
@@ -2802,7 +2802,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-client-types"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#88af9ef92e699cfc3561b11ffb9ff314fc32b2f9"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#982b39226670dbf7c5ce7f14d6456e1533439d30"
 dependencies = [
  "derive_more",
  "ibc-client-tendermint",
@@ -2833,7 +2833,7 @@ dependencies = [
 [[package]]
 name = "sov-client-types"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#88af9ef92e699cfc3561b11ffb9ff314fc32b2f9"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#982b39226670dbf7c5ce7f14d6456e1533439d30"
 dependencies = [
  "derive_more",
  "hex",
@@ -2867,7 +2867,7 @@ dependencies = [
 [[package]]
 name = "sov-ibc"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#88af9ef92e699cfc3561b11ffb9ff314fc32b2f9"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#982b39226670dbf7c5ce7f14d6456e1533439d30"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2894,7 +2894,7 @@ dependencies = [
 [[package]]
 name = "sov-ibc-proto"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#88af9ef92e699cfc3561b11ffb9ff314fc32b2f9"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#982b39226670dbf7c5ce7f14d6456e1533439d30"
 dependencies = [
  "ibc-proto",
  "informalsystems-pbjson",
@@ -2906,7 +2906,7 @@ dependencies = [
 [[package]]
 name = "sov-ibc-transfer"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#88af9ef92e699cfc3561b11ffb9ff314fc32b2f9"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#982b39226670dbf7c5ce7f14d6456e1533439d30"
 dependencies = [
  "anyhow",
  "borsh",

--- a/crates/provers/risc0/guest-celestia/Cargo.lock
+++ b/crates/provers/risc0/guest-celestia/Cargo.lock
@@ -448,9 +448,19 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4114279215a005bc675e386011e594e1d9b800918cea18fcadadcce864a2046b"
 dependencies = [
- "borsh-derive",
+ "borsh-derive 0.10.3",
  "bytes",
  "hashbrown 0.13.2",
+]
+
+[[package]]
+name = "borsh"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6362ed55def622cddc70a4746a68554d7b687713770de539e59a739b249f8ed"
+dependencies = [
+ "borsh-derive 1.5.1",
+ "cfg_aliases",
 ]
 
 [[package]]
@@ -464,6 +474,20 @@ dependencies = [
  "proc-macro-crate 0.1.5",
  "proc-macro2",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3ef8005764f53cd4dca619f5bf64cafd4664dada50ece25e4d81de54c80cc0b"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate 3.1.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+ "syn_derive",
 ]
 
 [[package]]
@@ -582,6 +606,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -1243,7 +1273,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
  "ibc-app-transfer-types",
  "ibc-core",
@@ -1253,13 +1283,13 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
- "borsh",
+ "borsh 1.5.1",
  "derive_more",
  "displaydoc",
  "ibc-core",
- "ibc-proto",
+ "ibc-proto 0.45.0",
  "primitive-types",
  "schemars",
  "serde",
@@ -1269,7 +1299,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
  "derive_more",
  "ibc-client-tendermint-types",
@@ -1286,14 +1316,14 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
  "displaydoc",
  "ibc-core-client-types",
  "ibc-core-commitment-types",
  "ibc-core-host-types",
  "ibc-primitives",
- "ibc-proto",
+ "ibc-proto 0.45.0",
  "serde",
  "tendermint 0.36.0",
  "tendermint-light-client-verifier",
@@ -1303,20 +1333,20 @@ dependencies = [
 [[package]]
 name = "ibc-client-wasm-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
  "base64 0.21.7",
  "displaydoc",
  "ibc-core-client",
  "ibc-core-host-types",
  "ibc-primitives",
- "ibc-proto",
+ "ibc-proto 0.45.0",
 ]
 
 [[package]]
 name = "ibc-core"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -1332,7 +1362,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
  "ibc-core-channel-types",
  "ibc-core-client",
@@ -1347,9 +1377,9 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
- "borsh",
+ "borsh 1.5.1",
  "derive_more",
  "displaydoc",
  "ibc-core-client-types",
@@ -1357,7 +1387,7 @@ dependencies = [
  "ibc-core-connection-types",
  "ibc-core-host-types",
  "ibc-primitives",
- "ibc-proto",
+ "ibc-proto 0.45.0",
  "schemars",
  "serde",
  "sha2 0.10.8",
@@ -1368,7 +1398,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
  "ibc-core-client-context",
  "ibc-core-client-types",
@@ -1381,7 +1411,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-context"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1397,15 +1427,15 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
- "borsh",
+ "borsh 1.5.1",
  "derive_more",
  "displaydoc",
  "ibc-core-commitment-types",
  "ibc-core-host-types",
  "ibc-primitives",
- "ibc-proto",
+ "ibc-proto 0.45.0",
  "schemars",
  "serde",
  "subtle-encoding",
@@ -1415,13 +1445,13 @@ dependencies = [
 [[package]]
 name = "ibc-core-commitment-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
- "borsh",
+ "borsh 1.5.1",
  "derive_more",
  "displaydoc",
  "ibc-primitives",
- "ibc-proto",
+ "ibc-proto 0.45.0",
  "ics23",
  "schemars",
  "serde",
@@ -1431,28 +1461,30 @@ dependencies = [
 [[package]]
 name = "ibc-core-connection"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
+ "ibc-client-wasm-types",
  "ibc-core-client",
  "ibc-core-connection-types",
  "ibc-core-handler-types",
  "ibc-core-host",
  "ibc-primitives",
+ "prost",
 ]
 
 [[package]]
 name = "ibc-core-connection-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
- "borsh",
+ "borsh 1.5.1",
  "derive_more",
  "displaydoc",
  "ibc-core-client-types",
  "ibc-core-commitment-types",
  "ibc-core-host-types",
  "ibc-primitives",
- "ibc-proto",
+ "ibc-proto 0.45.0",
  "schemars",
  "serde",
  "subtle-encoding",
@@ -1462,7 +1494,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -1477,9 +1509,9 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
- "borsh",
+ "borsh 1.5.1",
  "derive_more",
  "displaydoc",
  "ibc-core-channel-types",
@@ -1489,7 +1521,7 @@ dependencies = [
  "ibc-core-host-types",
  "ibc-core-router-types",
  "ibc-primitives",
- "ibc-proto",
+ "ibc-proto 0.45.0",
  "schemars",
  "serde",
  "subtle-encoding",
@@ -1499,7 +1531,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1517,9 +1549,9 @@ dependencies = [
 [[package]]
 name = "ibc-core-host-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
- "borsh",
+ "borsh 1.5.1",
  "derive_more",
  "displaydoc",
  "ibc-primitives",
@@ -1530,7 +1562,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-router"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1544,14 +1576,14 @@ dependencies = [
 [[package]]
 name = "ibc-core-router-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
- "borsh",
+ "borsh 1.5.1",
  "derive_more",
  "displaydoc",
  "ibc-core-host-types",
  "ibc-primitives",
- "ibc-proto",
+ "ibc-proto 0.45.0",
  "schemars",
  "serde",
  "subtle-encoding",
@@ -1561,7 +1593,7 @@ dependencies = [
 [[package]]
 name = "ibc-derive"
 version = "0.7.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1571,12 +1603,12 @@ dependencies = [
 [[package]]
 name = "ibc-primitives"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
- "borsh",
+ "borsh 1.5.1",
  "derive_more",
  "displaydoc",
- "ibc-proto",
+ "ibc-proto 0.45.0",
  "prost",
  "schemars",
  "serde",
@@ -1591,7 +1623,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66080040d5a4800d52966d55b055400f86b79c34b854b935bef03c87aacda62a"
 dependencies = [
  "base64 0.22.1",
- "borsh",
+ "bytes",
+ "flex-error",
+ "ics23",
+ "informalsystems-pbjson",
+ "prost",
+ "serde",
+ "subtle-encoding",
+ "tendermint-proto 0.36.0",
+]
+
+[[package]]
+name = "ibc-proto"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7002e679ad26dc29bd27dfa490bb689d121d03c1512bed9f646f75028165644d"
+dependencies = [
+ "base64 0.22.1",
+ "borsh 1.5.1",
  "bytes",
  "flex-error",
  "ics23",
@@ -1737,7 +1786,7 @@ version = "0.9.0"
 source = "git+https://github.com/penumbra-zone/jmt.git?rev=1d007e11cb68aa5ca13e9a5af4a12e6439d5f7b6#1d007e11cb68aa5ca13e9a5af4a12e6439d5f7b6"
 dependencies = [
  "anyhow",
- "borsh",
+ "borsh 0.10.3",
  "digest 0.10.7",
  "hashbrown 0.13.2",
  "hex",
@@ -1859,7 +1908,7 @@ name = "nmt-rs"
 version = "0.1.0"
 source = "git+https://github.com/Sovereign-Labs/nmt-rs.git?rev=d821332#d821332baa03aea625d23060dc239af57b9121f5"
 dependencies = [
- "borsh",
+ "borsh 0.10.3",
  "bytes",
  "serde",
  "sha2 0.10.8",
@@ -2706,7 +2755,7 @@ name = "sov-accounts"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "borsh",
+ "borsh 0.10.3",
  "serde",
  "serde_with",
  "sov-modules-api",
@@ -2719,7 +2768,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "bech32 0.11.0",
- "borsh",
+ "borsh 0.10.3",
  "serde",
  "sov-modules-api",
  "sov-state",
@@ -2732,7 +2781,7 @@ name = "sov-blob-storage"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "borsh",
+ "borsh 0.10.3",
  "hex",
  "serde",
  "sov-chain-state",
@@ -2763,7 +2812,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bech32 0.9.1",
- "borsh",
+ "borsh 0.10.3",
  "celestia-proto",
  "celestia-types",
  "hex",
@@ -2783,7 +2832,7 @@ name = "sov-celestia-client"
 version = "0.1.0"
 source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=b74f6eb#b74f6eb829d0e881f55dd8cd3fa938bf5f53e75c"
 dependencies = [
- "borsh",
+ "borsh 0.10.3",
  "derive_more",
  "ibc-client-tendermint",
  "ibc-core",
@@ -2820,7 +2869,7 @@ name = "sov-chain-state"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "borsh",
+ "borsh 0.10.3",
  "derivative",
  "serde",
  "sov-modules-api",
@@ -2871,7 +2920,7 @@ dependencies = [
  "ahash",
  "anyhow",
  "base64 0.21.7",
- "borsh",
+ "borsh 0.10.3",
  "derive_more",
  "ibc-app-transfer",
  "ibc-client-tendermint",
@@ -2895,7 +2944,7 @@ name = "sov-ibc-proto"
 version = "0.1.0"
 source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=b74f6eb#b74f6eb829d0e881f55dd8cd3fa938bf5f53e75c"
 dependencies = [
- "ibc-proto",
+ "ibc-proto 0.44.0",
  "informalsystems-pbjson",
  "prost",
  "serde",
@@ -2908,7 +2957,7 @@ version = "0.1.0"
 source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=b74f6eb#b74f6eb829d0e881f55dd8cd3fa938bf5f53e75c"
 dependencies = [
  "anyhow",
- "borsh",
+ "borsh 0.10.3",
  "derive_more",
  "ibc-app-transfer",
  "ibc-core",
@@ -2943,7 +2992,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "bincode",
- "borsh",
+ "borsh 0.10.3",
  "digest 0.10.7",
  "ed25519-dalek",
  "hex",
@@ -2959,7 +3008,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "bech32 0.11.0",
- "borsh",
+ "borsh 0.10.3",
  "derivative",
  "derive_more",
  "hex",
@@ -2995,7 +3044,7 @@ name = "sov-modules-stf-blueprint"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "borsh",
+ "borsh 0.10.3",
  "hex",
  "serde",
  "sov-modules-api",
@@ -3010,7 +3059,7 @@ name = "sov-prover-incentives"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "borsh",
+ "borsh 0.10.3",
  "serde",
  "sov-bank",
  "sov-chain-state",
@@ -3025,7 +3074,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "bincode",
- "borsh",
+ "borsh 0.10.3",
  "bytemuck",
  "crypto-bigint",
  "digest 0.10.7",
@@ -3047,7 +3096,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "borsh",
+ "borsh 0.10.3",
  "bytes",
  "digest 0.10.7",
  "hex",
@@ -3060,7 +3109,7 @@ name = "sov-sequencer-registry"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "borsh",
+ "borsh 0.10.3",
  "serde",
  "sov-bank",
  "sov-modules-api",
@@ -3075,7 +3124,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "bcs",
- "borsh",
+ "borsh 0.10.3",
  "derivative",
  "hex",
  "jmt",
@@ -3090,7 +3139,7 @@ name = "sov-stf-runner"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "borsh",
+ "borsh 0.10.3",
  "hex",
  "num_cpus",
  "serde",
@@ -3120,7 +3169,7 @@ name = "stf-starter"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "borsh",
+ "borsh 0.10.3",
  "serde",
  "serde_json",
  "sov-accounts",
@@ -3191,6 +3240,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "syn_derive"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1329189c02ff984e9736652b1631330da25eaa6bc639089ed4915d25446cbe7b"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
 ]
 
 [[package]]

--- a/crates/provers/risc0/guest-celestia/Cargo.lock
+++ b/crates/provers/risc0/guest-celestia/Cargo.lock
@@ -448,19 +448,9 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4114279215a005bc675e386011e594e1d9b800918cea18fcadadcce864a2046b"
 dependencies = [
- "borsh-derive 0.10.3",
+ "borsh-derive",
  "bytes",
  "hashbrown 0.13.2",
-]
-
-[[package]]
-name = "borsh"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6362ed55def622cddc70a4746a68554d7b687713770de539e59a739b249f8ed"
-dependencies = [
- "borsh-derive 1.5.1",
- "cfg_aliases",
 ]
 
 [[package]]
@@ -474,20 +464,6 @@ dependencies = [
  "proc-macro-crate 0.1.5",
  "proc-macro2",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "borsh-derive"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3ef8005764f53cd4dca619f5bf64cafd4664dada50ece25e4d81de54c80cc0b"
-dependencies = [
- "once_cell",
- "proc-macro-crate 3.1.0",
- "proc-macro2",
- "quote",
- "syn 2.0.66",
- "syn_derive",
 ]
 
 [[package]]
@@ -535,9 +511,9 @@ dependencies = [
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "369cfaf2a5bed5d8f8202073b2e093c9f508251de1551a0deb4253e4c7d80909"
+checksum = "1ee891b04274a59bd38b412188e24b849617b2e45a0fd8d057deb63e7403761b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -606,12 +582,6 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "cfg_aliases"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -1273,7 +1243,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
  "ibc-app-transfer-types",
  "ibc-core",
@@ -1283,9 +1253,9 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
- "borsh 1.5.1",
+ "borsh",
  "derive_more",
  "displaydoc",
  "ibc-core",
@@ -1299,7 +1269,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
  "derive_more",
  "ibc-client-tendermint-types",
@@ -1316,7 +1286,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
  "displaydoc",
  "ibc-core-client-types",
@@ -1333,7 +1303,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-wasm-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
  "base64 0.21.7",
  "displaydoc",
@@ -1346,7 +1316,7 @@ dependencies = [
 [[package]]
 name = "ibc-core"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -1362,7 +1332,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
  "ibc-core-channel-types",
  "ibc-core-client",
@@ -1377,9 +1347,9 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
- "borsh 1.5.1",
+ "borsh",
  "derive_more",
  "displaydoc",
  "ibc-core-client-types",
@@ -1398,7 +1368,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
  "ibc-core-client-context",
  "ibc-core-client-types",
@@ -1411,7 +1381,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-context"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1427,9 +1397,9 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
- "borsh 1.5.1",
+ "borsh",
  "derive_more",
  "displaydoc",
  "ibc-core-commitment-types",
@@ -1445,9 +1415,9 @@ dependencies = [
 [[package]]
 name = "ibc-core-commitment-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
- "borsh 1.5.1",
+ "borsh",
  "derive_more",
  "displaydoc",
  "ibc-primitives",
@@ -1461,7 +1431,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-connection"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
  "ibc-client-wasm-types",
  "ibc-core-client",
@@ -1475,9 +1445,9 @@ dependencies = [
 [[package]]
 name = "ibc-core-connection-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
- "borsh 1.5.1",
+ "borsh",
  "derive_more",
  "displaydoc",
  "ibc-core-client-types",
@@ -1494,7 +1464,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -1509,9 +1479,9 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
- "borsh 1.5.1",
+ "borsh",
  "derive_more",
  "displaydoc",
  "ibc-core-channel-types",
@@ -1531,7 +1501,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1549,9 +1519,9 @@ dependencies = [
 [[package]]
 name = "ibc-core-host-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
- "borsh 1.5.1",
+ "borsh",
  "derive_more",
  "displaydoc",
  "ibc-primitives",
@@ -1562,7 +1532,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-router"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1576,9 +1546,9 @@ dependencies = [
 [[package]]
 name = "ibc-core-router-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
- "borsh 1.5.1",
+ "borsh",
  "derive_more",
  "displaydoc",
  "ibc-core-host-types",
@@ -1593,7 +1563,7 @@ dependencies = [
 [[package]]
 name = "ibc-derive"
 version = "0.7.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1603,9 +1573,9 @@ dependencies = [
 [[package]]
 name = "ibc-primitives"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
- "borsh 1.5.1",
+ "borsh",
  "derive_more",
  "displaydoc",
  "ibc-proto",
@@ -1618,12 +1588,12 @@ dependencies = [
 
 [[package]]
 name = "ibc-proto"
-version = "0.45.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7002e679ad26dc29bd27dfa490bb689d121d03c1512bed9f646f75028165644d"
+checksum = "66080040d5a4800d52966d55b055400f86b79c34b854b935bef03c87aacda62a"
 dependencies = [
  "base64 0.22.1",
- "borsh 1.5.1",
+ "borsh",
  "bytes",
  "flex-error",
  "ics23",
@@ -1769,7 +1739,7 @@ version = "0.9.0"
 source = "git+https://github.com/penumbra-zone/jmt.git?rev=1d007e11cb68aa5ca13e9a5af4a12e6439d5f7b6#1d007e11cb68aa5ca13e9a5af4a12e6439d5f7b6"
 dependencies = [
  "anyhow",
- "borsh 0.10.3",
+ "borsh",
  "digest 0.10.7",
  "hashbrown 0.13.2",
  "hex",
@@ -1891,7 +1861,7 @@ name = "nmt-rs"
 version = "0.1.0"
 source = "git+https://github.com/Sovereign-Labs/nmt-rs.git?rev=d821332#d821332baa03aea625d23060dc239af57b9121f5"
 dependencies = [
- "borsh 0.10.3",
+ "borsh",
  "bytes",
  "serde",
  "sha2 0.10.8",
@@ -2143,9 +2113,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.84"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec96c6a92621310b51366f1e28d05ef11489516e93be030060e5fc12024a49d6"
+checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
 dependencies = [
  "unicode-ident",
 ]
@@ -2455,9 +2425,9 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.12.1"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f308135fef9fc398342da5472ce7c484529df23743fb7c734e0f3d472971e62"
+checksum = "2c3cc4c2511671f327125da14133d0c5c5d137f006a1017a16f557bc85b16286"
 dependencies = [
  "alloy-rlp",
  "ark-ff 0.3.0",
@@ -2479,9 +2449,9 @@ dependencies = [
 
 [[package]]
 name = "ruint-macro"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f86854cf50259291520509879a5c294c3c9a4c334e9ff65071c51e42ef1e2343"
+checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 
 [[package]]
 name = "rustc-hex"
@@ -2738,7 +2708,7 @@ name = "sov-accounts"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "borsh 0.10.3",
+ "borsh",
  "serde",
  "serde_with",
  "sov-modules-api",
@@ -2751,7 +2721,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "bech32 0.11.0",
- "borsh 0.10.3",
+ "borsh",
  "serde",
  "sov-modules-api",
  "sov-state",
@@ -2764,7 +2734,7 @@ name = "sov-blob-storage"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "borsh 0.10.3",
+ "borsh",
  "hex",
  "serde",
  "sov-chain-state",
@@ -2795,7 +2765,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bech32 0.9.1",
- "borsh 0.10.3",
+ "borsh",
  "celestia-proto",
  "celestia-types",
  "hex",
@@ -2813,9 +2783,9 @@ dependencies = [
 [[package]]
 name = "sov-celestia-client"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#ff9f3e9b5f1431a557b6a673e31c8cd264dbb59d"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#88af9ef92e699cfc3561b11ffb9ff314fc32b2f9"
 dependencies = [
- "borsh 0.10.3",
+ "borsh",
  "derive_more",
  "ibc-client-tendermint",
  "ibc-core",
@@ -2832,7 +2802,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-client-types"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#ff9f3e9b5f1431a557b6a673e31c8cd264dbb59d"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#88af9ef92e699cfc3561b11ffb9ff314fc32b2f9"
 dependencies = [
  "derive_more",
  "ibc-client-tendermint",
@@ -2851,7 +2821,7 @@ name = "sov-chain-state"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "borsh 0.10.3",
+ "borsh",
  "derivative",
  "serde",
  "sov-modules-api",
@@ -2863,7 +2833,7 @@ dependencies = [
 [[package]]
 name = "sov-client-types"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#ff9f3e9b5f1431a557b6a673e31c8cd264dbb59d"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#88af9ef92e699cfc3561b11ffb9ff314fc32b2f9"
 dependencies = [
  "derive_more",
  "hex",
@@ -2897,12 +2867,12 @@ dependencies = [
 [[package]]
 name = "sov-ibc"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#ff9f3e9b5f1431a557b6a673e31c8cd264dbb59d"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#88af9ef92e699cfc3561b11ffb9ff314fc32b2f9"
 dependencies = [
  "ahash",
  "anyhow",
  "base64 0.21.7",
- "borsh 0.10.3",
+ "borsh",
  "derive_more",
  "ibc-app-transfer",
  "ibc-client-tendermint",
@@ -2924,7 +2894,7 @@ dependencies = [
 [[package]]
 name = "sov-ibc-proto"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#ff9f3e9b5f1431a557b6a673e31c8cd264dbb59d"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#88af9ef92e699cfc3561b11ffb9ff314fc32b2f9"
 dependencies = [
  "ibc-proto",
  "informalsystems-pbjson",
@@ -2936,10 +2906,10 @@ dependencies = [
 [[package]]
 name = "sov-ibc-transfer"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#ff9f3e9b5f1431a557b6a673e31c8cd264dbb59d"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#88af9ef92e699cfc3561b11ffb9ff314fc32b2f9"
 dependencies = [
  "anyhow",
- "borsh 0.10.3",
+ "borsh",
  "derive_more",
  "ibc-app-transfer",
  "ibc-core",
@@ -2974,7 +2944,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "bincode",
- "borsh 0.10.3",
+ "borsh",
  "digest 0.10.7",
  "ed25519-dalek",
  "hex",
@@ -2990,7 +2960,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "bech32 0.11.0",
- "borsh 0.10.3",
+ "borsh",
  "derivative",
  "derive_more",
  "hex",
@@ -3026,7 +2996,7 @@ name = "sov-modules-stf-blueprint"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "borsh 0.10.3",
+ "borsh",
  "hex",
  "serde",
  "sov-modules-api",
@@ -3041,7 +3011,7 @@ name = "sov-prover-incentives"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "borsh 0.10.3",
+ "borsh",
  "serde",
  "sov-bank",
  "sov-chain-state",
@@ -3056,7 +3026,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "bincode",
- "borsh 0.10.3",
+ "borsh",
  "bytemuck",
  "crypto-bigint",
  "digest 0.10.7",
@@ -3078,7 +3048,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "borsh 0.10.3",
+ "borsh",
  "bytes",
  "digest 0.10.7",
  "hex",
@@ -3091,7 +3061,7 @@ name = "sov-sequencer-registry"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "borsh 0.10.3",
+ "borsh",
  "serde",
  "sov-bank",
  "sov-modules-api",
@@ -3106,7 +3076,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "bcs",
- "borsh 0.10.3",
+ "borsh",
  "derivative",
  "hex",
  "jmt",
@@ -3121,7 +3091,7 @@ name = "sov-stf-runner"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "borsh 0.10.3",
+ "borsh",
  "hex",
  "num_cpus",
  "serde",
@@ -3151,7 +3121,7 @@ name = "stf-starter"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "borsh 0.10.3",
+ "borsh",
  "serde",
  "serde_json",
  "sov-accounts",
@@ -3222,18 +3192,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "syn_derive"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1329189c02ff984e9736652b1631330da25eaa6bc639089ed4915d25446cbe7b"
-dependencies = [
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 2.0.66",
 ]
 
 [[package]]

--- a/crates/provers/risc0/guest-celestia/Cargo.lock
+++ b/crates/provers/risc0/guest-celestia/Cargo.lock
@@ -1289,7 +1289,7 @@ dependencies = [
  "derive_more",
  "displaydoc",
  "ibc-core",
- "ibc-proto 0.45.0",
+ "ibc-proto",
  "primitive-types",
  "schemars",
  "serde",
@@ -1323,7 +1323,7 @@ dependencies = [
  "ibc-core-commitment-types",
  "ibc-core-host-types",
  "ibc-primitives",
- "ibc-proto 0.45.0",
+ "ibc-proto",
  "serde",
  "tendermint 0.36.0",
  "tendermint-light-client-verifier",
@@ -1340,7 +1340,7 @@ dependencies = [
  "ibc-core-client",
  "ibc-core-host-types",
  "ibc-primitives",
- "ibc-proto 0.45.0",
+ "ibc-proto",
 ]
 
 [[package]]
@@ -1387,7 +1387,7 @@ dependencies = [
  "ibc-core-connection-types",
  "ibc-core-host-types",
  "ibc-primitives",
- "ibc-proto 0.45.0",
+ "ibc-proto",
  "schemars",
  "serde",
  "sha2 0.10.8",
@@ -1435,7 +1435,7 @@ dependencies = [
  "ibc-core-commitment-types",
  "ibc-core-host-types",
  "ibc-primitives",
- "ibc-proto 0.45.0",
+ "ibc-proto",
  "schemars",
  "serde",
  "subtle-encoding",
@@ -1451,7 +1451,7 @@ dependencies = [
  "derive_more",
  "displaydoc",
  "ibc-primitives",
- "ibc-proto 0.45.0",
+ "ibc-proto",
  "ics23",
  "schemars",
  "serde",
@@ -1484,7 +1484,7 @@ dependencies = [
  "ibc-core-commitment-types",
  "ibc-core-host-types",
  "ibc-primitives",
- "ibc-proto 0.45.0",
+ "ibc-proto",
  "schemars",
  "serde",
  "subtle-encoding",
@@ -1521,7 +1521,7 @@ dependencies = [
  "ibc-core-host-types",
  "ibc-core-router-types",
  "ibc-primitives",
- "ibc-proto 0.45.0",
+ "ibc-proto",
  "schemars",
  "serde",
  "subtle-encoding",
@@ -1583,7 +1583,7 @@ dependencies = [
  "displaydoc",
  "ibc-core-host-types",
  "ibc-primitives",
- "ibc-proto 0.45.0",
+ "ibc-proto",
  "schemars",
  "serde",
  "subtle-encoding",
@@ -1608,29 +1608,12 @@ dependencies = [
  "borsh 1.5.1",
  "derive_more",
  "displaydoc",
- "ibc-proto 0.45.0",
+ "ibc-proto",
  "prost",
  "schemars",
  "serde",
  "tendermint 0.36.0",
  "time",
-]
-
-[[package]]
-name = "ibc-proto"
-version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66080040d5a4800d52966d55b055400f86b79c34b854b935bef03c87aacda62a"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "flex-error",
- "ics23",
- "informalsystems-pbjson",
- "prost",
- "serde",
- "subtle-encoding",
- "tendermint-proto 0.36.0",
 ]
 
 [[package]]
@@ -2830,7 +2813,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-client"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=90591e5#90591e58d89dc5c2d1b912ed1db69c2f93dbc321"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#ff9f3e9b5f1431a557b6a673e31c8cd264dbb59d"
 dependencies = [
  "borsh 0.10.3",
  "derive_more",
@@ -2849,7 +2832,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-client-types"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=90591e5#90591e58d89dc5c2d1b912ed1db69c2f93dbc321"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#ff9f3e9b5f1431a557b6a673e31c8cd264dbb59d"
 dependencies = [
  "derive_more",
  "ibc-client-tendermint",
@@ -2880,7 +2863,7 @@ dependencies = [
 [[package]]
 name = "sov-client-types"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=90591e5#90591e58d89dc5c2d1b912ed1db69c2f93dbc321"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#ff9f3e9b5f1431a557b6a673e31c8cd264dbb59d"
 dependencies = [
  "derive_more",
  "hex",
@@ -2914,7 +2897,7 @@ dependencies = [
 [[package]]
 name = "sov-ibc"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=90591e5#90591e58d89dc5c2d1b912ed1db69c2f93dbc321"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#ff9f3e9b5f1431a557b6a673e31c8cd264dbb59d"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2941,9 +2924,9 @@ dependencies = [
 [[package]]
 name = "sov-ibc-proto"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=90591e5#90591e58d89dc5c2d1b912ed1db69c2f93dbc321"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#ff9f3e9b5f1431a557b6a673e31c8cd264dbb59d"
 dependencies = [
- "ibc-proto 0.44.0",
+ "ibc-proto",
  "informalsystems-pbjson",
  "prost",
  "serde",
@@ -2953,7 +2936,7 @@ dependencies = [
 [[package]]
 name = "sov-ibc-transfer"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=90591e5#90591e58d89dc5c2d1b912ed1db69c2f93dbc321"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#ff9f3e9b5f1431a557b6a673e31c8cd264dbb59d"
 dependencies = [
  "anyhow",
  "borsh 0.10.3",

--- a/crates/provers/risc0/guest-celestia/Cargo.lock
+++ b/crates/provers/risc0/guest-celestia/Cargo.lock
@@ -2830,7 +2830,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-client"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=b74f6eb#b74f6eb829d0e881f55dd8cd3fa938bf5f53e75c"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=90591e5#90591e58d89dc5c2d1b912ed1db69c2f93dbc321"
 dependencies = [
  "borsh 0.10.3",
  "derive_more",
@@ -2849,11 +2849,10 @@ dependencies = [
 [[package]]
 name = "sov-celestia-client-types"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=b74f6eb#b74f6eb829d0e881f55dd8cd3fa938bf5f53e75c"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=90591e5#90591e58d89dc5c2d1b912ed1db69c2f93dbc321"
 dependencies = [
  "derive_more",
  "ibc-client-tendermint",
- "ibc-client-wasm-types",
  "ibc-core",
  "prost",
  "serde",
@@ -2881,7 +2880,7 @@ dependencies = [
 [[package]]
 name = "sov-client-types"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=b74f6eb#b74f6eb829d0e881f55dd8cd3fa938bf5f53e75c"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=90591e5#90591e58d89dc5c2d1b912ed1db69c2f93dbc321"
 dependencies = [
  "derive_more",
  "hex",
@@ -2915,7 +2914,7 @@ dependencies = [
 [[package]]
 name = "sov-ibc"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=b74f6eb#b74f6eb829d0e881f55dd8cd3fa938bf5f53e75c"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=90591e5#90591e58d89dc5c2d1b912ed1db69c2f93dbc321"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2942,7 +2941,7 @@ dependencies = [
 [[package]]
 name = "sov-ibc-proto"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=b74f6eb#b74f6eb829d0e881f55dd8cd3fa938bf5f53e75c"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=90591e5#90591e58d89dc5c2d1b912ed1db69c2f93dbc321"
 dependencies = [
  "ibc-proto 0.44.0",
  "informalsystems-pbjson",
@@ -2954,7 +2953,7 @@ dependencies = [
 [[package]]
 name = "sov-ibc-transfer"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=b74f6eb#b74f6eb829d0e881f55dd8cd3fa938bf5f53e75c"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=90591e5#90591e58d89dc5c2d1b912ed1db69c2f93dbc321"
 dependencies = [
  "anyhow",
  "borsh 0.10.3",

--- a/crates/provers/risc0/guest-celestia/Cargo.toml
+++ b/crates/provers/risc0/guest-celestia/Cargo.toml
@@ -48,9 +48,9 @@ ibc-app-transfer            = { git = "https://github.com/cosmos/ibc-rs.git", br
 ibc-primitives              = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/allow-country-party-client-state-wrapper" }
 ibc-client-wasm-types       = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/allow-country-party-client-state-wrapper" }
 
-sov-ibc                     = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "b74f6eb"  }
-sov-ibc-transfer            = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "b74f6eb"  }
-sov-celestia-client         = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "b74f6eb"  }
+sov-ibc                     = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "90591e5"  }
+sov-ibc-transfer            = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "90591e5"  }
+sov-celestia-client         = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "90591e5"  }
 
 sha2                            = { git = "https://github.com/risc0/RustCrypto-hashes", tag = "sha2-v0.10.8-risczero.0" }
 ed25519-dalek                   = { git = "https://github.com/risc0/curve25519-dalek", tag = "curve25519-4.1.0-risczero.1" }

--- a/crates/provers/risc0/guest-celestia/Cargo.toml
+++ b/crates/provers/risc0/guest-celestia/Cargo.toml
@@ -41,12 +41,12 @@ sov-mock-zkvm                   = { path = "../../../../vendor/sovereign-sdk/ada
 sov-kernels                     = { path = "../../../../vendor/sovereign-sdk/module-system/sov-kernels" }
 sov-celestia-adapter            = { path = "../../../../vendor/sovereign-sdk/adapters/celestia" }
 
-ibc-core                    = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/allow-country-party-client-state-wrapper" }
-ibc-core-client             = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/allow-country-party-client-state-wrapper" }
-ibc-client-tendermint       = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/allow-country-party-client-state-wrapper" }
-ibc-app-transfer            = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/allow-country-party-client-state-wrapper" }
-ibc-primitives              = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/allow-country-party-client-state-wrapper" }
-ibc-client-wasm-types       = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/allow-country-party-client-state-wrapper" }
+ibc-core                    = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/downgrade-borsh" }
+ibc-core-client             = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/downgrade-borsh" }
+ibc-client-tendermint       = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/downgrade-borsh" }
+ibc-app-transfer            = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/downgrade-borsh" }
+ibc-primitives              = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/downgrade-borsh" }
+ibc-client-wasm-types       = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/downgrade-borsh" }
 
 sov-ibc                     = { git = "https://github.com/informalsystems/sovereign-ibc.git", branch = "soares/update-ibc-rs"  }
 sov-ibc-transfer            = { git = "https://github.com/informalsystems/sovereign-ibc.git", branch = "soares/update-ibc-rs"  }

--- a/crates/provers/risc0/guest-celestia/Cargo.toml
+++ b/crates/provers/risc0/guest-celestia/Cargo.toml
@@ -41,12 +41,12 @@ sov-mock-zkvm                   = { path = "../../../../vendor/sovereign-sdk/ada
 sov-kernels                     = { path = "../../../../vendor/sovereign-sdk/module-system/sov-kernels" }
 sov-celestia-adapter            = { path = "../../../../vendor/sovereign-sdk/adapters/celestia" }
 
-ibc-core                    = { git = "https://github.com/cosmos/ibc-rs.git", rev = "67841b3c" }
-ibc-core-client             = { git = "https://github.com/cosmos/ibc-rs.git", rev = "67841b3c" }
-ibc-client-tendermint       = { git = "https://github.com/cosmos/ibc-rs.git", rev = "67841b3c" }
-ibc-app-transfer            = { git = "https://github.com/cosmos/ibc-rs.git", rev = "67841b3c" }
-ibc-primitives              = { git = "https://github.com/cosmos/ibc-rs.git", rev = "67841b3c" }
-ibc-client-wasm-types       = { git = "https://github.com/cosmos/ibc-rs.git", rev = "67841b3c" }
+ibc-core                    = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/allow-country-party-client-state-wrapper" }
+ibc-core-client             = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/allow-country-party-client-state-wrapper" }
+ibc-client-tendermint       = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/allow-country-party-client-state-wrapper" }
+ibc-app-transfer            = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/allow-country-party-client-state-wrapper" }
+ibc-primitives              = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/allow-country-party-client-state-wrapper" }
+ibc-client-wasm-types       = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/allow-country-party-client-state-wrapper" }
 
 sov-ibc                     = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "b74f6eb"  }
 sov-ibc-transfer            = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "b74f6eb"  }

--- a/crates/provers/risc0/guest-celestia/Cargo.toml
+++ b/crates/provers/risc0/guest-celestia/Cargo.toml
@@ -48,9 +48,9 @@ ibc-app-transfer            = { git = "https://github.com/cosmos/ibc-rs.git", br
 ibc-primitives              = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/allow-country-party-client-state-wrapper" }
 ibc-client-wasm-types       = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/allow-country-party-client-state-wrapper" }
 
-sov-ibc                     = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "90591e5"  }
-sov-ibc-transfer            = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "90591e5"  }
-sov-celestia-client         = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "90591e5"  }
+sov-ibc                     = { git = "https://github.com/informalsystems/sovereign-ibc.git", branch = "soares/update-ibc-rs"  }
+sov-ibc-transfer            = { git = "https://github.com/informalsystems/sovereign-ibc.git", branch = "soares/update-ibc-rs"  }
+sov-celestia-client         = { git = "https://github.com/informalsystems/sovereign-ibc.git", branch = "soares/update-ibc-rs"  }
 
 sha2                            = { git = "https://github.com/risc0/RustCrypto-hashes", tag = "sha2-v0.10.8-risczero.0" }
 ed25519-dalek                   = { git = "https://github.com/risc0/curve25519-dalek", tag = "curve25519-4.1.0-risczero.1" }

--- a/crates/provers/risc0/guest-mock/Cargo.lock
+++ b/crates/provers/risc0/guest-mock/Cargo.lock
@@ -2186,7 +2186,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-client"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#88af9ef92e699cfc3561b11ffb9ff314fc32b2f9"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#982b39226670dbf7c5ce7f14d6456e1533439d30"
 dependencies = [
  "borsh",
  "derive_more",
@@ -2205,7 +2205,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-client-types"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#88af9ef92e699cfc3561b11ffb9ff314fc32b2f9"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#982b39226670dbf7c5ce7f14d6456e1533439d30"
 dependencies = [
  "derive_more",
  "ibc-client-tendermint",
@@ -2236,7 +2236,7 @@ dependencies = [
 [[package]]
 name = "sov-client-types"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#88af9ef92e699cfc3561b11ffb9ff314fc32b2f9"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#982b39226670dbf7c5ce7f14d6456e1533439d30"
 dependencies = [
  "derive_more",
  "hex",
@@ -2250,7 +2250,7 @@ dependencies = [
 [[package]]
 name = "sov-ibc"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#88af9ef92e699cfc3561b11ffb9ff314fc32b2f9"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#982b39226670dbf7c5ce7f14d6456e1533439d30"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2277,7 +2277,7 @@ dependencies = [
 [[package]]
 name = "sov-ibc-proto"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#88af9ef92e699cfc3561b11ffb9ff314fc32b2f9"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#982b39226670dbf7c5ce7f14d6456e1533439d30"
 dependencies = [
  "ibc-proto",
  "informalsystems-pbjson",
@@ -2289,7 +2289,7 @@ dependencies = [
 [[package]]
 name = "sov-ibc-transfer"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#88af9ef92e699cfc3561b11ffb9ff314fc32b2f9"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#982b39226670dbf7c5ce7f14d6456e1533439d30"
 dependencies = [
  "anyhow",
  "borsh",

--- a/crates/provers/risc0/guest-mock/Cargo.lock
+++ b/crates/provers/risc0/guest-mock/Cargo.lock
@@ -1024,7 +1024,7 @@ dependencies = [
  "derive_more",
  "displaydoc",
  "ibc-core",
- "ibc-proto 0.45.0",
+ "ibc-proto",
  "primitive-types",
  "schemars",
  "serde",
@@ -1058,7 +1058,7 @@ dependencies = [
  "ibc-core-commitment-types",
  "ibc-core-host-types",
  "ibc-primitives",
- "ibc-proto 0.45.0",
+ "ibc-proto",
  "serde",
  "tendermint",
  "tendermint-light-client-verifier",
@@ -1075,7 +1075,7 @@ dependencies = [
  "ibc-core-client",
  "ibc-core-host-types",
  "ibc-primitives",
- "ibc-proto 0.45.0",
+ "ibc-proto",
 ]
 
 [[package]]
@@ -1122,7 +1122,7 @@ dependencies = [
  "ibc-core-connection-types",
  "ibc-core-host-types",
  "ibc-primitives",
- "ibc-proto 0.45.0",
+ "ibc-proto",
  "schemars",
  "serde",
  "sha2 0.10.8",
@@ -1170,7 +1170,7 @@ dependencies = [
  "ibc-core-commitment-types",
  "ibc-core-host-types",
  "ibc-primitives",
- "ibc-proto 0.45.0",
+ "ibc-proto",
  "schemars",
  "serde",
  "subtle-encoding",
@@ -1186,7 +1186,7 @@ dependencies = [
  "derive_more",
  "displaydoc",
  "ibc-primitives",
- "ibc-proto 0.45.0",
+ "ibc-proto",
  "ics23",
  "schemars",
  "serde",
@@ -1219,7 +1219,7 @@ dependencies = [
  "ibc-core-commitment-types",
  "ibc-core-host-types",
  "ibc-primitives",
- "ibc-proto 0.45.0",
+ "ibc-proto",
  "schemars",
  "serde",
  "subtle-encoding",
@@ -1256,7 +1256,7 @@ dependencies = [
  "ibc-core-host-types",
  "ibc-core-router-types",
  "ibc-primitives",
- "ibc-proto 0.45.0",
+ "ibc-proto",
  "schemars",
  "serde",
  "subtle-encoding",
@@ -1318,7 +1318,7 @@ dependencies = [
  "displaydoc",
  "ibc-core-host-types",
  "ibc-primitives",
- "ibc-proto 0.45.0",
+ "ibc-proto",
  "schemars",
  "serde",
  "subtle-encoding",
@@ -1343,29 +1343,12 @@ dependencies = [
  "borsh 1.5.1",
  "derive_more",
  "displaydoc",
- "ibc-proto 0.45.0",
+ "ibc-proto",
  "prost",
  "schemars",
  "serde",
  "tendermint",
  "time",
-]
-
-[[package]]
-name = "ibc-proto"
-version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66080040d5a4800d52966d55b055400f86b79c34b854b935bef03c87aacda62a"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "flex-error",
- "ics23",
- "informalsystems-pbjson",
- "prost",
- "serde",
- "subtle-encoding",
- "tendermint-proto",
 ]
 
 [[package]]
@@ -2256,7 +2239,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-client"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=90591e5#90591e58d89dc5c2d1b912ed1db69c2f93dbc321"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#ff9f3e9b5f1431a557b6a673e31c8cd264dbb59d"
 dependencies = [
  "borsh 0.10.3",
  "derive_more",
@@ -2275,7 +2258,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-client-types"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=90591e5#90591e58d89dc5c2d1b912ed1db69c2f93dbc321"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#ff9f3e9b5f1431a557b6a673e31c8cd264dbb59d"
 dependencies = [
  "derive_more",
  "ibc-client-tendermint",
@@ -2306,7 +2289,7 @@ dependencies = [
 [[package]]
 name = "sov-client-types"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=90591e5#90591e58d89dc5c2d1b912ed1db69c2f93dbc321"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#ff9f3e9b5f1431a557b6a673e31c8cd264dbb59d"
 dependencies = [
  "derive_more",
  "hex",
@@ -2320,7 +2303,7 @@ dependencies = [
 [[package]]
 name = "sov-ibc"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=90591e5#90591e58d89dc5c2d1b912ed1db69c2f93dbc321"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#ff9f3e9b5f1431a557b6a673e31c8cd264dbb59d"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2347,9 +2330,9 @@ dependencies = [
 [[package]]
 name = "sov-ibc-proto"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=90591e5#90591e58d89dc5c2d1b912ed1db69c2f93dbc321"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#ff9f3e9b5f1431a557b6a673e31c8cd264dbb59d"
 dependencies = [
- "ibc-proto 0.44.0",
+ "ibc-proto",
  "informalsystems-pbjson",
  "prost",
  "serde",
@@ -2359,7 +2342,7 @@ dependencies = [
 [[package]]
 name = "sov-ibc-transfer"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=90591e5#90591e58d89dc5c2d1b912ed1db69c2f93dbc321"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#ff9f3e9b5f1431a557b6a673e31c8cd264dbb59d"
 dependencies = [
  "anyhow",
  "borsh 0.10.3",

--- a/crates/provers/risc0/guest-mock/Cargo.lock
+++ b/crates/provers/risc0/guest-mock/Cargo.lock
@@ -340,9 +340,19 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4114279215a005bc675e386011e594e1d9b800918cea18fcadadcce864a2046b"
 dependencies = [
- "borsh-derive",
+ "borsh-derive 0.10.3",
  "bytes",
  "hashbrown 0.13.2",
+]
+
+[[package]]
+name = "borsh"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6362ed55def622cddc70a4746a68554d7b687713770de539e59a739b249f8ed"
+dependencies = [
+ "borsh-derive 1.5.1",
+ "cfg_aliases",
 ]
 
 [[package]]
@@ -356,6 +366,20 @@ dependencies = [
  "proc-macro-crate 0.1.5",
  "proc-macro2",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3ef8005764f53cd4dca619f5bf64cafd4664dada50ece25e4d81de54c80cc0b"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate 3.1.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+ "syn_derive",
 ]
 
 [[package]]
@@ -438,6 +462,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -978,7 +1008,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
  "ibc-app-transfer-types",
  "ibc-core",
@@ -988,13 +1018,13 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
- "borsh",
+ "borsh 1.5.1",
  "derive_more",
  "displaydoc",
  "ibc-core",
- "ibc-proto",
+ "ibc-proto 0.45.0",
  "primitive-types",
  "schemars",
  "serde",
@@ -1004,7 +1034,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
  "derive_more",
  "ibc-client-tendermint-types",
@@ -1021,14 +1051,14 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
  "displaydoc",
  "ibc-core-client-types",
  "ibc-core-commitment-types",
  "ibc-core-host-types",
  "ibc-primitives",
- "ibc-proto",
+ "ibc-proto 0.45.0",
  "serde",
  "tendermint",
  "tendermint-light-client-verifier",
@@ -1038,20 +1068,20 @@ dependencies = [
 [[package]]
 name = "ibc-client-wasm-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
  "base64 0.21.7",
  "displaydoc",
  "ibc-core-client",
  "ibc-core-host-types",
  "ibc-primitives",
- "ibc-proto",
+ "ibc-proto 0.45.0",
 ]
 
 [[package]]
 name = "ibc-core"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -1067,7 +1097,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
  "ibc-core-channel-types",
  "ibc-core-client",
@@ -1082,9 +1112,9 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
- "borsh",
+ "borsh 1.5.1",
  "derive_more",
  "displaydoc",
  "ibc-core-client-types",
@@ -1092,7 +1122,7 @@ dependencies = [
  "ibc-core-connection-types",
  "ibc-core-host-types",
  "ibc-primitives",
- "ibc-proto",
+ "ibc-proto 0.45.0",
  "schemars",
  "serde",
  "sha2 0.10.8",
@@ -1103,7 +1133,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
  "ibc-core-client-context",
  "ibc-core-client-types",
@@ -1116,7 +1146,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-context"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1132,15 +1162,15 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
- "borsh",
+ "borsh 1.5.1",
  "derive_more",
  "displaydoc",
  "ibc-core-commitment-types",
  "ibc-core-host-types",
  "ibc-primitives",
- "ibc-proto",
+ "ibc-proto 0.45.0",
  "schemars",
  "serde",
  "subtle-encoding",
@@ -1150,13 +1180,13 @@ dependencies = [
 [[package]]
 name = "ibc-core-commitment-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
- "borsh",
+ "borsh 1.5.1",
  "derive_more",
  "displaydoc",
  "ibc-primitives",
- "ibc-proto",
+ "ibc-proto 0.45.0",
  "ics23",
  "schemars",
  "serde",
@@ -1166,28 +1196,30 @@ dependencies = [
 [[package]]
 name = "ibc-core-connection"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
+ "ibc-client-wasm-types",
  "ibc-core-client",
  "ibc-core-connection-types",
  "ibc-core-handler-types",
  "ibc-core-host",
  "ibc-primitives",
+ "prost",
 ]
 
 [[package]]
 name = "ibc-core-connection-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
- "borsh",
+ "borsh 1.5.1",
  "derive_more",
  "displaydoc",
  "ibc-core-client-types",
  "ibc-core-commitment-types",
  "ibc-core-host-types",
  "ibc-primitives",
- "ibc-proto",
+ "ibc-proto 0.45.0",
  "schemars",
  "serde",
  "subtle-encoding",
@@ -1197,7 +1229,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -1212,9 +1244,9 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
- "borsh",
+ "borsh 1.5.1",
  "derive_more",
  "displaydoc",
  "ibc-core-channel-types",
@@ -1224,7 +1256,7 @@ dependencies = [
  "ibc-core-host-types",
  "ibc-core-router-types",
  "ibc-primitives",
- "ibc-proto",
+ "ibc-proto 0.45.0",
  "schemars",
  "serde",
  "subtle-encoding",
@@ -1234,7 +1266,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1252,9 +1284,9 @@ dependencies = [
 [[package]]
 name = "ibc-core-host-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
- "borsh",
+ "borsh 1.5.1",
  "derive_more",
  "displaydoc",
  "ibc-primitives",
@@ -1265,7 +1297,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-router"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1279,14 +1311,14 @@ dependencies = [
 [[package]]
 name = "ibc-core-router-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
- "borsh",
+ "borsh 1.5.1",
  "derive_more",
  "displaydoc",
  "ibc-core-host-types",
  "ibc-primitives",
- "ibc-proto",
+ "ibc-proto 0.45.0",
  "schemars",
  "serde",
  "subtle-encoding",
@@ -1296,7 +1328,7 @@ dependencies = [
 [[package]]
 name = "ibc-derive"
 version = "0.7.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1306,12 +1338,12 @@ dependencies = [
 [[package]]
 name = "ibc-primitives"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?rev=67841b3c#67841b3c3730b259fd239ce9496ab965ec0ce5b3"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
 dependencies = [
- "borsh",
+ "borsh 1.5.1",
  "derive_more",
  "displaydoc",
- "ibc-proto",
+ "ibc-proto 0.45.0",
  "prost",
  "schemars",
  "serde",
@@ -1326,7 +1358,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66080040d5a4800d52966d55b055400f86b79c34b854b935bef03c87aacda62a"
 dependencies = [
  "base64 0.22.1",
- "borsh",
+ "bytes",
+ "flex-error",
+ "ics23",
+ "informalsystems-pbjson",
+ "prost",
+ "serde",
+ "subtle-encoding",
+ "tendermint-proto",
+]
+
+[[package]]
+name = "ibc-proto"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7002e679ad26dc29bd27dfa490bb689d121d03c1512bed9f646f75028165644d"
+dependencies = [
+ "base64 0.22.1",
+ "borsh 1.5.1",
  "bytes",
  "flex-error",
  "ics23",
@@ -1454,7 +1503,7 @@ version = "0.9.0"
 source = "git+https://github.com/penumbra-zone/jmt.git?rev=1d007e11cb68aa5ca13e9a5af4a12e6439d5f7b6#1d007e11cb68aa5ca13e9a5af4a12e6439d5f7b6"
 dependencies = [
  "anyhow",
- "borsh",
+ "borsh 0.10.3",
  "digest 0.10.7",
  "hashbrown 0.13.2",
  "hex",
@@ -1693,6 +1742,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
 dependencies = [
  "toml_edit",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -2131,7 +2203,7 @@ name = "sov-accounts"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "borsh",
+ "borsh 0.10.3",
  "serde",
  "serde_with",
  "sov-modules-api",
@@ -2144,7 +2216,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "bech32",
- "borsh",
+ "borsh 0.10.3",
  "serde",
  "sov-modules-api",
  "sov-state",
@@ -2157,7 +2229,7 @@ name = "sov-blob-storage"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "borsh",
+ "borsh 0.10.3",
  "hex",
  "serde",
  "sov-chain-state",
@@ -2186,7 +2258,7 @@ name = "sov-celestia-client"
 version = "0.1.0"
 source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=b74f6eb#b74f6eb829d0e881f55dd8cd3fa938bf5f53e75c"
 dependencies = [
- "borsh",
+ "borsh 0.10.3",
  "derive_more",
  "ibc-client-tendermint",
  "ibc-core",
@@ -2223,7 +2295,7 @@ name = "sov-chain-state"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "borsh",
+ "borsh 0.10.3",
  "derivative",
  "serde",
  "sov-modules-api",
@@ -2254,7 +2326,7 @@ dependencies = [
  "ahash",
  "anyhow",
  "base64 0.21.7",
- "borsh",
+ "borsh 0.10.3",
  "derive_more",
  "ibc-app-transfer",
  "ibc-client-tendermint",
@@ -2278,7 +2350,7 @@ name = "sov-ibc-proto"
 version = "0.1.0"
 source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=b74f6eb#b74f6eb829d0e881f55dd8cd3fa938bf5f53e75c"
 dependencies = [
- "ibc-proto",
+ "ibc-proto 0.44.0",
  "informalsystems-pbjson",
  "prost",
  "serde",
@@ -2291,7 +2363,7 @@ version = "0.1.0"
 source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=b74f6eb#b74f6eb829d0e881f55dd8cd3fa938bf5f53e75c"
 dependencies = [
  "anyhow",
- "borsh",
+ "borsh 0.10.3",
  "derive_more",
  "ibc-app-transfer",
  "ibc-core",
@@ -2326,7 +2398,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "borsh",
+ "borsh 0.10.3",
  "bytes",
  "hex",
  "serde",
@@ -2341,7 +2413,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "bincode",
- "borsh",
+ "borsh 0.10.3",
  "digest 0.10.7",
  "ed25519-dalek",
  "hex",
@@ -2357,7 +2429,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "bech32",
- "borsh",
+ "borsh 0.10.3",
  "derivative",
  "derive_more",
  "hex",
@@ -2393,7 +2465,7 @@ name = "sov-modules-stf-blueprint"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "borsh",
+ "borsh 0.10.3",
  "hex",
  "serde",
  "sov-modules-api",
@@ -2408,7 +2480,7 @@ name = "sov-prover-incentives"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "borsh",
+ "borsh 0.10.3",
  "serde",
  "sov-bank",
  "sov-chain-state",
@@ -2423,7 +2495,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "bincode",
- "borsh",
+ "borsh 0.10.3",
  "bytemuck",
  "crypto-bigint",
  "digest 0.10.7",
@@ -2445,7 +2517,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "borsh",
+ "borsh 0.10.3",
  "bytes",
  "digest 0.10.7",
  "hex",
@@ -2458,7 +2530,7 @@ name = "sov-sequencer-registry"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "borsh",
+ "borsh 0.10.3",
  "serde",
  "sov-bank",
  "sov-modules-api",
@@ -2473,7 +2545,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "bcs",
- "borsh",
+ "borsh 0.10.3",
  "derivative",
  "hex",
  "jmt",
@@ -2488,7 +2560,7 @@ name = "sov-stf-runner"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "borsh",
+ "borsh 0.10.3",
  "hex",
  "num_cpus",
  "serde",
@@ -2518,7 +2590,7 @@ name = "stf-starter"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "borsh",
+ "borsh 0.10.3",
  "serde",
  "serde_json",
  "sov-accounts",
@@ -2589,6 +2661,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "syn_derive"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1329189c02ff984e9736652b1631330da25eaa6bc639089ed4915d25446cbe7b"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
 ]
 
 [[package]]

--- a/crates/provers/risc0/guest-mock/Cargo.lock
+++ b/crates/provers/risc0/guest-mock/Cargo.lock
@@ -340,19 +340,9 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4114279215a005bc675e386011e594e1d9b800918cea18fcadadcce864a2046b"
 dependencies = [
- "borsh-derive 0.10.3",
+ "borsh-derive",
  "bytes",
  "hashbrown 0.13.2",
-]
-
-[[package]]
-name = "borsh"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6362ed55def622cddc70a4746a68554d7b687713770de539e59a739b249f8ed"
-dependencies = [
- "borsh-derive 1.5.1",
- "cfg_aliases",
 ]
 
 [[package]]
@@ -366,20 +356,6 @@ dependencies = [
  "proc-macro-crate 0.1.5",
  "proc-macro2",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "borsh-derive"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3ef8005764f53cd4dca619f5bf64cafd4664dada50ece25e4d81de54c80cc0b"
-dependencies = [
- "once_cell",
- "proc-macro-crate 3.1.0",
- "proc-macro2",
- "quote",
- "syn 2.0.66",
- "syn_derive",
 ]
 
 [[package]]
@@ -427,9 +403,9 @@ dependencies = [
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "369cfaf2a5bed5d8f8202073b2e093c9f508251de1551a0deb4253e4c7d80909"
+checksum = "1ee891b04274a59bd38b412188e24b849617b2e45a0fd8d057deb63e7403761b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -462,12 +438,6 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "cfg_aliases"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -1008,7 +978,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
  "ibc-app-transfer-types",
  "ibc-core",
@@ -1018,9 +988,9 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
- "borsh 1.5.1",
+ "borsh",
  "derive_more",
  "displaydoc",
  "ibc-core",
@@ -1034,7 +1004,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
  "derive_more",
  "ibc-client-tendermint-types",
@@ -1051,7 +1021,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
  "displaydoc",
  "ibc-core-client-types",
@@ -1068,7 +1038,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-wasm-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
  "base64 0.21.7",
  "displaydoc",
@@ -1081,7 +1051,7 @@ dependencies = [
 [[package]]
 name = "ibc-core"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -1097,7 +1067,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
  "ibc-core-channel-types",
  "ibc-core-client",
@@ -1112,9 +1082,9 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
- "borsh 1.5.1",
+ "borsh",
  "derive_more",
  "displaydoc",
  "ibc-core-client-types",
@@ -1133,7 +1103,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
  "ibc-core-client-context",
  "ibc-core-client-types",
@@ -1146,7 +1116,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-context"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1162,9 +1132,9 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
- "borsh 1.5.1",
+ "borsh",
  "derive_more",
  "displaydoc",
  "ibc-core-commitment-types",
@@ -1180,9 +1150,9 @@ dependencies = [
 [[package]]
 name = "ibc-core-commitment-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
- "borsh 1.5.1",
+ "borsh",
  "derive_more",
  "displaydoc",
  "ibc-primitives",
@@ -1196,7 +1166,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-connection"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
  "ibc-client-wasm-types",
  "ibc-core-client",
@@ -1210,9 +1180,9 @@ dependencies = [
 [[package]]
 name = "ibc-core-connection-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
- "borsh 1.5.1",
+ "borsh",
  "derive_more",
  "displaydoc",
  "ibc-core-client-types",
@@ -1229,7 +1199,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -1244,9 +1214,9 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
- "borsh 1.5.1",
+ "borsh",
  "derive_more",
  "displaydoc",
  "ibc-core-channel-types",
@@ -1266,7 +1236,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1284,9 +1254,9 @@ dependencies = [
 [[package]]
 name = "ibc-core-host-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
- "borsh 1.5.1",
+ "borsh",
  "derive_more",
  "displaydoc",
  "ibc-primitives",
@@ -1297,7 +1267,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-router"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1311,9 +1281,9 @@ dependencies = [
 [[package]]
 name = "ibc-core-router-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
- "borsh 1.5.1",
+ "borsh",
  "derive_more",
  "displaydoc",
  "ibc-core-host-types",
@@ -1328,7 +1298,7 @@ dependencies = [
 [[package]]
 name = "ibc-derive"
 version = "0.7.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1338,9 +1308,9 @@ dependencies = [
 [[package]]
 name = "ibc-primitives"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/allow-country-party-client-state-wrapper#af749814c1dda9fe3039c25f96ae4e2aac0ce361"
+source = "git+https://github.com/cosmos/ibc-rs.git?branch=rano/downgrade-borsh#d90295e3ff386d786c996d8ff3a42e79d4c4dcea"
 dependencies = [
- "borsh 1.5.1",
+ "borsh",
  "derive_more",
  "displaydoc",
  "ibc-proto",
@@ -1353,12 +1323,12 @@ dependencies = [
 
 [[package]]
 name = "ibc-proto"
-version = "0.45.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7002e679ad26dc29bd27dfa490bb689d121d03c1512bed9f646f75028165644d"
+checksum = "66080040d5a4800d52966d55b055400f86b79c34b854b935bef03c87aacda62a"
 dependencies = [
  "base64 0.22.1",
- "borsh 1.5.1",
+ "borsh",
  "bytes",
  "flex-error",
  "ics23",
@@ -1486,7 +1456,7 @@ version = "0.9.0"
 source = "git+https://github.com/penumbra-zone/jmt.git?rev=1d007e11cb68aa5ca13e9a5af4a12e6439d5f7b6#1d007e11cb68aa5ca13e9a5af4a12e6439d5f7b6"
 dependencies = [
  "anyhow",
- "borsh 0.10.3",
+ "borsh",
  "digest 0.10.7",
  "hashbrown 0.13.2",
  "hex",
@@ -1728,33 +1698,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.84"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec96c6a92621310b51366f1e28d05ef11489516e93be030060e5fc12024a49d6"
+checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
 dependencies = [
  "unicode-ident",
 ]
@@ -2186,7 +2133,7 @@ name = "sov-accounts"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "borsh 0.10.3",
+ "borsh",
  "serde",
  "serde_with",
  "sov-modules-api",
@@ -2199,7 +2146,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "bech32",
- "borsh 0.10.3",
+ "borsh",
  "serde",
  "sov-modules-api",
  "sov-state",
@@ -2212,7 +2159,7 @@ name = "sov-blob-storage"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "borsh 0.10.3",
+ "borsh",
  "hex",
  "serde",
  "sov-chain-state",
@@ -2239,9 +2186,9 @@ dependencies = [
 [[package]]
 name = "sov-celestia-client"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#ff9f3e9b5f1431a557b6a673e31c8cd264dbb59d"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#88af9ef92e699cfc3561b11ffb9ff314fc32b2f9"
 dependencies = [
- "borsh 0.10.3",
+ "borsh",
  "derive_more",
  "ibc-client-tendermint",
  "ibc-core",
@@ -2258,7 +2205,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-client-types"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#ff9f3e9b5f1431a557b6a673e31c8cd264dbb59d"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#88af9ef92e699cfc3561b11ffb9ff314fc32b2f9"
 dependencies = [
  "derive_more",
  "ibc-client-tendermint",
@@ -2277,7 +2224,7 @@ name = "sov-chain-state"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "borsh 0.10.3",
+ "borsh",
  "derivative",
  "serde",
  "sov-modules-api",
@@ -2289,7 +2236,7 @@ dependencies = [
 [[package]]
 name = "sov-client-types"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#ff9f3e9b5f1431a557b6a673e31c8cd264dbb59d"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#88af9ef92e699cfc3561b11ffb9ff314fc32b2f9"
 dependencies = [
  "derive_more",
  "hex",
@@ -2303,12 +2250,12 @@ dependencies = [
 [[package]]
 name = "sov-ibc"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#ff9f3e9b5f1431a557b6a673e31c8cd264dbb59d"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#88af9ef92e699cfc3561b11ffb9ff314fc32b2f9"
 dependencies = [
  "ahash",
  "anyhow",
  "base64 0.21.7",
- "borsh 0.10.3",
+ "borsh",
  "derive_more",
  "ibc-app-transfer",
  "ibc-client-tendermint",
@@ -2330,7 +2277,7 @@ dependencies = [
 [[package]]
 name = "sov-ibc-proto"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#ff9f3e9b5f1431a557b6a673e31c8cd264dbb59d"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#88af9ef92e699cfc3561b11ffb9ff314fc32b2f9"
 dependencies = [
  "ibc-proto",
  "informalsystems-pbjson",
@@ -2342,10 +2289,10 @@ dependencies = [
 [[package]]
 name = "sov-ibc-transfer"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#ff9f3e9b5f1431a557b6a673e31c8cd264dbb59d"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?branch=soares/update-ibc-rs#88af9ef92e699cfc3561b11ffb9ff314fc32b2f9"
 dependencies = [
  "anyhow",
- "borsh 0.10.3",
+ "borsh",
  "derive_more",
  "ibc-app-transfer",
  "ibc-core",
@@ -2380,7 +2327,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "borsh 0.10.3",
+ "borsh",
  "bytes",
  "hex",
  "serde",
@@ -2395,7 +2342,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "bincode",
- "borsh 0.10.3",
+ "borsh",
  "digest 0.10.7",
  "ed25519-dalek",
  "hex",
@@ -2411,7 +2358,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "bech32",
- "borsh 0.10.3",
+ "borsh",
  "derivative",
  "derive_more",
  "hex",
@@ -2447,7 +2394,7 @@ name = "sov-modules-stf-blueprint"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "borsh 0.10.3",
+ "borsh",
  "hex",
  "serde",
  "sov-modules-api",
@@ -2462,7 +2409,7 @@ name = "sov-prover-incentives"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "borsh 0.10.3",
+ "borsh",
  "serde",
  "sov-bank",
  "sov-chain-state",
@@ -2477,7 +2424,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "bincode",
- "borsh 0.10.3",
+ "borsh",
  "bytemuck",
  "crypto-bigint",
  "digest 0.10.7",
@@ -2499,7 +2446,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "borsh 0.10.3",
+ "borsh",
  "bytes",
  "digest 0.10.7",
  "hex",
@@ -2512,7 +2459,7 @@ name = "sov-sequencer-registry"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "borsh 0.10.3",
+ "borsh",
  "serde",
  "sov-bank",
  "sov-modules-api",
@@ -2527,7 +2474,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "bcs",
- "borsh 0.10.3",
+ "borsh",
  "derivative",
  "hex",
  "jmt",
@@ -2542,7 +2489,7 @@ name = "sov-stf-runner"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "borsh 0.10.3",
+ "borsh",
  "hex",
  "num_cpus",
  "serde",
@@ -2572,7 +2519,7 @@ name = "stf-starter"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "borsh 0.10.3",
+ "borsh",
  "serde",
  "serde_json",
  "sov-accounts",
@@ -2643,18 +2590,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "syn_derive"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1329189c02ff984e9736652b1631330da25eaa6bc639089ed4915d25446cbe7b"
-dependencies = [
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 2.0.66",
 ]
 
 [[package]]

--- a/crates/provers/risc0/guest-mock/Cargo.lock
+++ b/crates/provers/risc0/guest-mock/Cargo.lock
@@ -2256,7 +2256,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-client"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=b74f6eb#b74f6eb829d0e881f55dd8cd3fa938bf5f53e75c"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=90591e5#90591e58d89dc5c2d1b912ed1db69c2f93dbc321"
 dependencies = [
  "borsh 0.10.3",
  "derive_more",
@@ -2275,11 +2275,10 @@ dependencies = [
 [[package]]
 name = "sov-celestia-client-types"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=b74f6eb#b74f6eb829d0e881f55dd8cd3fa938bf5f53e75c"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=90591e5#90591e58d89dc5c2d1b912ed1db69c2f93dbc321"
 dependencies = [
  "derive_more",
  "ibc-client-tendermint",
- "ibc-client-wasm-types",
  "ibc-core",
  "prost",
  "serde",
@@ -2307,7 +2306,7 @@ dependencies = [
 [[package]]
 name = "sov-client-types"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=b74f6eb#b74f6eb829d0e881f55dd8cd3fa938bf5f53e75c"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=90591e5#90591e58d89dc5c2d1b912ed1db69c2f93dbc321"
 dependencies = [
  "derive_more",
  "hex",
@@ -2321,7 +2320,7 @@ dependencies = [
 [[package]]
 name = "sov-ibc"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=b74f6eb#b74f6eb829d0e881f55dd8cd3fa938bf5f53e75c"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=90591e5#90591e58d89dc5c2d1b912ed1db69c2f93dbc321"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2348,7 +2347,7 @@ dependencies = [
 [[package]]
 name = "sov-ibc-proto"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=b74f6eb#b74f6eb829d0e881f55dd8cd3fa938bf5f53e75c"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=90591e5#90591e58d89dc5c2d1b912ed1db69c2f93dbc321"
 dependencies = [
  "ibc-proto 0.44.0",
  "informalsystems-pbjson",
@@ -2360,7 +2359,7 @@ dependencies = [
 [[package]]
 name = "sov-ibc-transfer"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=b74f6eb#b74f6eb829d0e881f55dd8cd3fa938bf5f53e75c"
+source = "git+https://github.com/informalsystems/sovereign-ibc.git?rev=90591e5#90591e58d89dc5c2d1b912ed1db69c2f93dbc321"
 dependencies = [
  "anyhow",
  "borsh 0.10.3",

--- a/crates/provers/risc0/guest-mock/Cargo.toml
+++ b/crates/provers/risc0/guest-mock/Cargo.toml
@@ -27,12 +27,12 @@ sov-kernels                 = { version = "0.3.0" }
 stf-starter = { path = "../../../stf" }
 
 [patch.crates-io]
-ibc-core                    = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/allow-country-party-client-state-wrapper" }
-ibc-core-client             = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/allow-country-party-client-state-wrapper" }
-ibc-client-tendermint       = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/allow-country-party-client-state-wrapper" }
-ibc-app-transfer            = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/allow-country-party-client-state-wrapper" }
-ibc-primitives              = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/allow-country-party-client-state-wrapper" }
-ibc-client-wasm-types       = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/allow-country-party-client-state-wrapper" }
+ibc-core                    = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/downgrade-borsh" }
+ibc-core-client             = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/downgrade-borsh" }
+ibc-client-tendermint       = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/downgrade-borsh" }
+ibc-app-transfer            = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/downgrade-borsh" }
+ibc-primitives              = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/downgrade-borsh" }
+ibc-client-wasm-types       = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/downgrade-borsh" }
 
 sov-ibc                     = { git = "https://github.com/informalsystems/sovereign-ibc.git", branch = "soares/update-ibc-rs"  }
 sov-ibc-transfer            = { git = "https://github.com/informalsystems/sovereign-ibc.git", branch = "soares/update-ibc-rs"  }

--- a/crates/provers/risc0/guest-mock/Cargo.toml
+++ b/crates/provers/risc0/guest-mock/Cargo.toml
@@ -34,9 +34,9 @@ ibc-app-transfer            = { git = "https://github.com/cosmos/ibc-rs.git", br
 ibc-primitives              = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/allow-country-party-client-state-wrapper" }
 ibc-client-wasm-types       = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/allow-country-party-client-state-wrapper" }
 
-sov-ibc                     = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "90591e5"  }
-sov-ibc-transfer            = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "90591e5"  }
-sov-celestia-client         = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "90591e5"  }
+sov-ibc                     = { git = "https://github.com/informalsystems/sovereign-ibc.git", branch = "soares/update-ibc-rs"  }
+sov-ibc-transfer            = { git = "https://github.com/informalsystems/sovereign-ibc.git", branch = "soares/update-ibc-rs"  }
+sov-celestia-client         = { git = "https://github.com/informalsystems/sovereign-ibc.git", branch = "soares/update-ibc-rs"  }
 
 sov-modules-api                 = { path = "../../../../vendor/sovereign-sdk/module-system/sov-modules-api" }
 sov-state                       = { path = "../../../../vendor/sovereign-sdk/module-system/sov-state" }

--- a/crates/provers/risc0/guest-mock/Cargo.toml
+++ b/crates/provers/risc0/guest-mock/Cargo.toml
@@ -34,9 +34,9 @@ ibc-app-transfer            = { git = "https://github.com/cosmos/ibc-rs.git", br
 ibc-primitives              = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/allow-country-party-client-state-wrapper" }
 ibc-client-wasm-types       = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/allow-country-party-client-state-wrapper" }
 
-sov-ibc                     = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "b74f6eb"  }
-sov-ibc-transfer            = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "b74f6eb"  }
-sov-celestia-client         = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "b74f6eb"  }
+sov-ibc                     = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "90591e5"  }
+sov-ibc-transfer            = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "90591e5"  }
+sov-celestia-client         = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "90591e5"  }
 
 sov-modules-api                 = { path = "../../../../vendor/sovereign-sdk/module-system/sov-modules-api" }
 sov-state                       = { path = "../../../../vendor/sovereign-sdk/module-system/sov-state" }

--- a/crates/provers/risc0/guest-mock/Cargo.toml
+++ b/crates/provers/risc0/guest-mock/Cargo.toml
@@ -27,12 +27,12 @@ sov-kernels                 = { version = "0.3.0" }
 stf-starter = { path = "../../../stf" }
 
 [patch.crates-io]
-ibc-core                    = { git = "https://github.com/cosmos/ibc-rs.git", rev = "67841b3c" }
-ibc-core-client             = { git = "https://github.com/cosmos/ibc-rs.git", rev = "67841b3c" }
-ibc-client-tendermint       = { git = "https://github.com/cosmos/ibc-rs.git", rev = "67841b3c" }
-ibc-app-transfer            = { git = "https://github.com/cosmos/ibc-rs.git", rev = "67841b3c" }
-ibc-primitives              = { git = "https://github.com/cosmos/ibc-rs.git", rev = "67841b3c" }
-ibc-client-wasm-types       = { git = "https://github.com/cosmos/ibc-rs.git", rev = "67841b3c" }
+ibc-core                    = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/allow-country-party-client-state-wrapper" }
+ibc-core-client             = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/allow-country-party-client-state-wrapper" }
+ibc-client-tendermint       = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/allow-country-party-client-state-wrapper" }
+ibc-app-transfer            = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/allow-country-party-client-state-wrapper" }
+ibc-primitives              = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/allow-country-party-client-state-wrapper" }
+ibc-client-wasm-types       = { git = "https://github.com/cosmos/ibc-rs.git", branch = "rano/allow-country-party-client-state-wrapper" }
 
 sov-ibc                     = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "b74f6eb"  }
 sov-ibc-transfer            = { git = "https://github.com/informalsystems/sovereign-ibc.git", rev = "b74f6eb"  }

--- a/crates/stf/src/genesis_config.rs
+++ b/crates/stf/src/genesis_config.rs
@@ -5,7 +5,6 @@
 use std::convert::AsRef;
 use std::path::{Path, PathBuf};
 
-use anyhow::Context as _;
 use sov_accounts::AccountConfig;
 use sov_bank::BankConfig;
 use sov_ibc::ExampleModuleConfig;
@@ -65,17 +64,6 @@ impl GenesisPaths {
             prover_incentives_genesis_path: dir.as_ref().join("prover_incentives.json"),
         }
     }
-}
-
-pub(crate) fn get_genesis_config<S: Spec, Da: DaSpec>(
-    genesis_paths: &GenesisPaths,
-) -> anyhow::Result<<Runtime<S, Da> as RuntimeTrait<S, Da>>::GenesisConfig> {
-    create_genesis_config(genesis_paths).with_context(|| {
-        format!(
-            "Unable to read genesis configuration from: {}",
-            genesis_paths
-        )
-    })
 }
 
 /// Creates a new [`GenesisConfig`] from the files contained in the given

--- a/flake.lock
+++ b/flake.lock
@@ -89,11 +89,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1717430266,
-        "narHash": "sha256-EWy2Qbkl/HUwmO8KDBzgDQf+4rl+fLiPFvp3nUSWcxc=",
+        "lastModified": 1717459389,
+        "narHash": "sha256-I8/plBsua4/NZ5bKgj+z7/ThiWuud1YFwLsn1QQ5PgE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d125f0e4d85f1517b639d4a8f848175da46fcd3e",
+        "rev": "3b01abcc24846ae49957b30f4345bab4b3f1d14b",
         "type": "github"
       },
       "original": {
@@ -136,11 +136,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1717553884,
-        "narHash": "sha256-+t3XaYEvlMo5BUJ/6C6RZcEfBTWFVUdMHpNoqUU+pSE=",
+        "lastModified": 1717640276,
+        "narHash": "sha256-xtWJuHl0Zq1/pibvU7V8+qad4fcNLP4yerO54nr4Hec=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "8795c817dfab19243a33387a16c98d2df4075bb3",
+        "rev": "96161e19677e2ae639c41147e422da4d6ec48240",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -89,11 +89,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1716715802,
-        "narHash": "sha256-usk0vE7VlxPX8jOavrtpOqphdfqEQpf9lgedlY/r66c=",
+        "lastModified": 1717430266,
+        "narHash": "sha256-EWy2Qbkl/HUwmO8KDBzgDQf+4rl+fLiPFvp3nUSWcxc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e2dd4e18cc1c7314e24154331bae07df76eb582f",
+        "rev": "d125f0e4d85f1517b639d4a8f848175da46fcd3e",
         "type": "github"
       },
       "original": {
@@ -136,11 +136,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1716862669,
-        "narHash": "sha256-7oTPM9lcdwiI1cpRC313B+lHawocgpY5F07N+Rbm5Uk=",
+        "lastModified": 1717553884,
+        "narHash": "sha256-+t3XaYEvlMo5BUJ/6C6RZcEfBTWFVUdMHpNoqUU+pSE=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "47b2d15658b37716393b2463a019000dbd6ce4bc",
+        "rev": "8795c817dfab19243a33387a16c98d2df4075bb3",
         "type": "github"
       },
       "original": {

--- a/nix/rollup.nix
+++ b/nix/rollup.nix
@@ -6,7 +6,7 @@
 ,   risc0-circuit
 }:
 let
-    sov-ibc-hash = "sha256-eyPIz8l7MvWn37pY7V/3gS/N6/CuQ0vJaCAmgaH5334=";
+    sov-ibc-hash = "sha256-nWEGgA//68mvs0ELWlJcB3eQl/1akvoRxBTQhAXgcOk=";
     ibc-rs-hash = "sha256-mahb4LxE3mOvYomNRCHo5CLaJ3rI/hxpe68nAS01OFM=";
 
     rollup-guest-src = nixpkgs.stdenv.mkDerivation {

--- a/nix/rollup.nix
+++ b/nix/rollup.nix
@@ -6,7 +6,7 @@
 ,   risc0-circuit
 }:
 let
-    sov-ibc-hash = "sha256-Wpr0hZt9mmikLNeIju7grA05y56RvSnfyLk9mQyd8jw=";
+    sov-ibc-hash = "sha256-eyPIz8l7MvWn37pY7V/3gS/N6/CuQ0vJaCAmgaH5334=";
     ibc-rs-hash = "sha256-mahb4LxE3mOvYomNRCHo5CLaJ3rI/hxpe68nAS01OFM=";
 
     rollup-guest-src = nixpkgs.stdenv.mkDerivation {

--- a/nix/rollup.nix
+++ b/nix/rollup.nix
@@ -7,7 +7,7 @@
 }:
 let
     sov-ibc-hash = "sha256-Wpr0hZt9mmikLNeIju7grA05y56RvSnfyLk9mQyd8jw=";
-    ibc-rs-hash = "sha256-Rew8AV3wuQ90ft0uAyysfdfHYejCqSDz66Wo9Tf0lW0=";
+    ibc-rs-hash = "sha256-mahb4LxE3mOvYomNRCHo5CLaJ3rI/hxpe68nAS01OFM=";
 
     rollup-guest-src = nixpkgs.stdenv.mkDerivation {
         name = "rollup-guest-src";

--- a/nix/rollup.nix
+++ b/nix/rollup.nix
@@ -6,7 +6,7 @@
 ,   risc0-circuit
 }:
 let
-    sov-ibc-hash = "sha256-QexZn8nBuBZgLl8oPFvDqYvMMq9Tj2Hzg5To0cGgzNA=";
+    sov-ibc-hash = "sha256-Mi1fZe109dug9uip1fpK1TqvWBHI8hij8Alkrw4UtUo=";
     ibc-rs-hash = "sha256-AnRsdl3njOCh0o44GU5uDvX4caxcEitH2Ic3sRu/uIs=";
 
     rollup-guest-src = nixpkgs.stdenv.mkDerivation {

--- a/nix/rollup.nix
+++ b/nix/rollup.nix
@@ -6,8 +6,8 @@
 ,   risc0-circuit
 }:
 let
-    sov-ibc-hash = "sha256-nWEGgA//68mvs0ELWlJcB3eQl/1akvoRxBTQhAXgcOk=";
-    ibc-rs-hash = "sha256-mahb4LxE3mOvYomNRCHo5CLaJ3rI/hxpe68nAS01OFM=";
+    sov-ibc-hash = "sha256-QexZn8nBuBZgLl8oPFvDqYvMMq9Tj2Hzg5To0cGgzNA=";
+    ibc-rs-hash = "sha256-AnRsdl3njOCh0o44GU5uDvX4caxcEitH2Ic3sRu/uIs=";
 
     rollup-guest-src = nixpkgs.stdenv.mkDerivation {
         name = "rollup-guest-src";


### PR DESCRIPTION
Update ibc-rs to support https://github.com/cosmos/ibc-rs/pull/1246

Requires a special branch from `cosmos/ibc-rs` which downgrades borsh: `rano/downgrade-borsh`